### PR TITLE
fix(glyph): resolvable holder identity, address→tokens route, O(1) counts/listing, canonical refs

### DIFF
--- a/electrumx/lib/script.py
+++ b/electrumx/lib/script.py
@@ -433,35 +433,88 @@ class Script(object):
         return script
 
     @classmethod
+    def _walk_ops(cls, script):
+        '''Yield (opcode, data_len, op_start, op_end) for each opcode in the
+        script, consuming push operands and 36-byte input-ref operands so that
+        operand bytes are never mis-parsed as opcodes. Raises on truncation.'''
+        ops = []
+        n = 0
+        length = len(script)
+        while n < length:
+            start = n
+            op = script[n]
+            n += 1
+            if op <= OpCodes.OP_PUSHDATA4:
+                if op < OpCodes.OP_PUSHDATA1:
+                    dlen = op
+                elif op == OpCodes.OP_PUSHDATA1:
+                    dlen = script[n]; n += 1
+                elif op == OpCodes.OP_PUSHDATA2:
+                    dlen, = unpack_le_uint16_from(script[n:n + 2]); n += 2
+                else:
+                    dlen, = unpack_le_uint32_from(script[n:n + 4]); n += 4
+                n += dlen
+                if n > length:
+                    raise IndexError('truncated push')
+                ops.append((op, dlen, start, n))
+            elif op in INPUT_REF_OPS:
+                n += 36
+                if n > length:
+                    raise IndexError('truncated ref')
+                ops.append((op, 36, start, n))
+            else:
+                ops.append((op, 0, start, n))
+        return ops
+
+    @classmethod
     def base_locking_script(cls, script):
-        '''Return the base locking script with any leading Radiant input-ref
-        commitment preamble removed.
+        '''Return the owner's base locking script (the spendable P2PKH/P2SH)
+        embedded in a Radiant token output.
 
-        Radiant token outputs prepend a "ref preamble" to an otherwise standard
-        locking script, e.g. an NFT pays to:
+        Token scripts wrap a standard pay-to-address with Glyph/token machinery,
+        and the address sits in different places depending on the contract:
 
-            OP_PUSHINPUTREFSINGLETON <36-byte ref> OP_DROP <P2PKH ...>
+            NFT:  OP_PUSHINPUTREFSINGLETON <ref> OP_DROP <P2PKH>      (address last)
+            FT:   <P2PKH> OP_STATESEPARATOR OP_PUSHINPUTREF <ref> ...  (address first)
 
         For per-address ownership we want the hashX/scripthash of the underlying
-        address (the ``<P2PKH ...>`` tail), so that a wallet can look up the
-        tokens it holds using its normal address scripthash.  This strips the
-        leading run of input-ref ops (each followed by a 36-byte operand) and
-        the OP_DROP/OP_2DROP ops that consume them, returning the remainder.
-
-        For a plain (non-token) script there is no preamble, so the script is
-        returned unchanged.  Used together with ``hashX_from_script`` to derive
-        the recipient's base-address hashX.  Symmetry of credit/debit accounting
-        does not depend on this being a "clean" address for exotic scripts: the
-        value is computed once at output creation and read back verbatim when
-        the output is spent.
+        address so a wallet can list the tokens it holds using its normal address
+        scripthash. We therefore locate the standard P2PKH (or P2SH) template
+        wherever it appears — walking opcodes so ref/data bytes can't produce a
+        false match — and return just that sub-script. Falls back to stripping a
+        leading input-ref preamble (and then the whole script) for exotic
+        non-standard scripts; credit/debit symmetry only needs the value to be
+        computed identically at create and spend time (the b'rb' side table
+        stores it verbatim).
         '''
+        try:
+            ops = cls._walk_ops(script)
+        except Exception:
+            return script
+
+        # P2PKH: OP_DUP OP_HASH160 <push20> OP_EQUALVERIFY OP_CHECKSIG
+        for i in range(len(ops) - 4):
+            if (ops[i][0] == OpCodes.OP_DUP
+                    and ops[i + 1][0] == OpCodes.OP_HASH160
+                    and ops[i + 2][0] == 0x14 and ops[i + 2][1] == 20
+                    and ops[i + 3][0] == OpCodes.OP_EQUALVERIFY
+                    and ops[i + 4][0] == OpCodes.OP_CHECKSIG):
+                return script[ops[i][2]:ops[i + 4][3]]
+        # P2SH: OP_HASH160 <push20> OP_EQUAL
+        for i in range(len(ops) - 2):
+            if (ops[i][0] == OpCodes.OP_HASH160
+                    and ops[i + 1][0] == 0x14 and ops[i + 1][1] == 20
+                    and ops[i + 2][0] == OpCodes.OP_EQUAL):
+                return script[ops[i][2]:ops[i + 2][3]]
+
+        # Fallback: strip a leading input-ref preamble (+ DROP/2DROP), then
+        # return the remainder (or the whole script if nothing remains).
         try:
             n = 0
             length = len(script)
             while n < length:
                 op = script[n]
                 if op in INPUT_REF_OPS:
-                    # ref op + 36-byte operand
                     if n + 1 + 36 > length:
                         break
                     n += 1 + 36
@@ -470,7 +523,6 @@ class Script(object):
                 else:
                     break
             remainder = script[n:]
-            # Guard against a script that is nothing but a ref preamble.
             return remainder if remainder else script
         except Exception:
             return script

--- a/electrumx/server/analytics_index.py
+++ b/electrumx/server/analytics_index.py
@@ -1,3 +1,4 @@
+import heapq
 import json
 import struct
 from collections import defaultdict
@@ -492,25 +493,46 @@ class AnalyticsIndex:
         return self._get_summary(AnalyticsDBKeys.SUMMARY + b'age_distribution', {label: 0 for _, label in AGE_BUCKETS})
 
     def get_top_addresses(self, limit: int = 100, offset: int = 0) -> Dict[str, Any]:
-        rows = []
+        """Rich list (top RXD balances).
+
+        A global top-N is inherently a scan of the balance keyspace, but we keep
+        it cheap: a single *sequential* iteration feeding a bounded min-heap of
+        size ``offset+limit`` (so memory is O(page), not O(all addresses)), and
+        we resolve the display address only for the returned page rather than
+        doing a random DB read per address (the previous version's timeout
+        cause). Result is cached by the REST layer.
+        """
         prefix = AnalyticsDBKeys.BALANCE
+        need = offset + limit
+        heap = []  # min-heap of (amount, hashX); smallest of the top-`need` at root
+        total = 0
         for key, raw in self.db.utxo_db.iterator(prefix=prefix):
             amount = struct.unpack('<Q', raw)[0]
             if amount <= 0:
                 continue
-            hashX = key[2:]
+            total += 1
+            if need <= 0:
+                continue
+            entry = (amount, key[2:])
+            if len(heap) < need:
+                heapq.heappush(heap, entry)
+            elif amount > heap[0][0]:
+                heapq.heapreplace(heap, entry)
+
+        top = sorted(heap, key=lambda t: t[0], reverse=True)[offset:offset + limit]
+        rows = []
+        for amount, hashX in top:
             display = self.db.utxo_db.get(self._display_key(hashX))
             rows.append({
                 'hashX': hashX.hex(),
                 'address': display.decode() if display else hashX.hex(),
                 'balance': amount,
             })
-        rows.sort(key=lambda item: item['balance'], reverse=True)
         return {
-            'total': len(rows),
+            'total': total,
             'limit': limit,
             'offset': offset,
-            'rows': rows[offset:offset + limit],
+            'rows': rows,
         }
 
     def get_movement(self, days: int = 30) -> Dict[str, Any]:

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -695,9 +695,13 @@ class BlockProcessor:
                 # The base hashX is persisted per-outpoint (b'rb' + outpoint) so
                 # the matching debit can be applied symmetrically on spend.
                 if self.glyph_index and all_refs_dedup:
-                    base_hashX = script_hashX(Script.base_locking_script(txout.pk_script))
+                    base_script = Script.base_locking_script(txout.pk_script)
+                    base_hashX = script_hashX(base_script)
                     put_data(b'rb' + cache_key, base_hashX)
-                    balance_credits.append((base_hashX, txout.value, list(all_refs_dedup.keys())))
+                    # Carry base_script so the glyph index can persist a
+                    # resolvable owner identity (GO: hashX -> base scriptPubKey).
+                    balance_credits.append((base_hashX, txout.value,
+                                            list(all_refs_dedup.keys()), base_script))
 
             append_hashXs(hashXs)
             update_touched(hashXs)

--- a/electrumx/server/glyph_api.py
+++ b/electrumx/server/glyph_api.py
@@ -161,21 +161,21 @@ class GlyphAPIMixin:
         Get the indexed Glyph token for a 36-byte reference.
 
         Args:
-            ref: 36-byte reference in hex (72 characters) — txid(32, internal
-                 byte order) + vout(4, little-endian), i.e. a packed ref.
+            ref: token reference, either as 72 hex chars (txid internal-order +
+                 little-endian vout) or the display ``txid_vout`` form.
 
         Returns:
-            The token record dict, or None if no token is indexed for this ref.
+            The token record dict (including a resolvable ``owner`` for
+            single-holder tokens and a ``holder_count``), or None if no token is
+            indexed for this ref.
         """
         self.bump_cost(2.0)
 
-        if len(ref) != 72:
-            return {'error': 'Invalid ref format. Expected 72 hex characters'}
-
+        from electrumx.server.glyph_index import parse_ref_any
         try:
-            ref_bytes = bytes.fromhex(ref)
-        except ValueError:
-            return {'error': 'Invalid hex in ref'}
+            ref_bytes = parse_ref_any(ref)
+        except Exception:
+            return {'error': 'Invalid ref format. Expected 72 hex chars or txid_vout'}
 
         if not getattr(self, 'glyph_index', None):
             return {'error': 'Glyph indexing not enabled'}
@@ -188,7 +188,20 @@ class GlyphAPIMixin:
         if not token:
             return None
 
-        return to_jsonsafe(self.glyph_index._token_to_dict(token))
+        record = self.glyph_index._token_to_dict(token)
+        # Attach a resolvable current owner for the marketplace/provenance layer.
+        # Well-defined for single-holder tokens (NFTs); for multi-holder FTs the
+        # caller should use /tokens/{ref}/holders instead.
+        try:
+            holders = self.glyph_index.get_token_holders(ref_bytes, limit=2)
+            hs = holders.get('holders', [])
+            record['holder_count'] = len(hs)
+            record['owner'] = hs[0] if len(hs) == 1 else None
+        except Exception:
+            record['holder_count'] = None
+            record['owner'] = None
+
+        return to_jsonsafe(record)
 
     async def glyph_validate_protocols(self, protocols: list):
         """
@@ -376,10 +389,9 @@ class GlyphAPIMixin:
         
         try:
             scripthash_bytes = bytes.fromhex(scripthash)
-            txid, vout = parse_ref(ref)
-            from electrumx.server.glyph_index import pack_ref
-            ref_bytes = pack_ref(hex_str_to_hash(txid), vout)
-            
+            from electrumx.server.glyph_index import parse_ref_any
+            ref_bytes = parse_ref_any(ref)  # accepts txid_vout or 72-hex
+
             balance = self.glyph_index.get_balance(scripthash_bytes, ref_bytes)
             return {'confirmed': balance, 'unconfirmed': 0}
         except Exception as e:

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -11,7 +11,8 @@ from typing import Optional, Dict, Any, List, Tuple, Set
 from collections import defaultdict
 
 from electrumx.lib import util
-from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash, sha256, HASHX_LEN
+from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash, sha256, HASHX_LEN, Base58, Base58Error
+from electrumx.lib.script import Script, ScriptError, OpCodes
 from electrumx.lib.util import pack_be_uint32, encode_undo, decode_undo
 from electrumx.lib.glyph import (
     GLYPH_MAGIC,
@@ -47,7 +48,8 @@ class GlyphDBKeys:
     BY_NAME = b'GN'            # GN + name_hash -> ref (for search)
     BY_TICKER = b'GK'          # GK + ticker -> ref (for FT lookup)
     SUPPLY = b'GS'             # GS + ref -> current supply (FT only)
-    HOLDER_BY_REF = b'GR'      # GR + ref + scripthash -> amount (reverse of BALANCE)
+    HOLDER_BY_REF = b'GR'      # GR + ref + hashX -> amount (reverse of BALANCE)
+    OWNER = b'GO'              # GO + hashX -> base scriptPubKey (resolvable owner identity for holder rows)
     UNDO = b'GXU'              # GXU + height(be) -> binary undo entries
     KEY_REVEALS = b'GKR'       # GKR + ref -> CBOR key reveal record (Phase 6 / REP-3009)
     CONTRACT_TO_TOKEN = b'GC'  # GC + contract_ref(36) -> token_ref(36) (R6 reverse index)
@@ -79,6 +81,41 @@ def unpack_ref(data: bytes) -> Tuple[bytes, int]:
     return txid, vout
 
 
+def ref_to_display(ref: bytes) -> str:
+    """Render a 36-byte ref as the canonical display form ``txid_vout``.
+
+    The txid is shown in big-endian (block-explorer / wallet) order and the
+    vout as a decimal integer, e.g. ``b3d8…cf06_0``.  This is the canonical
+    *output* ref format across the API; :func:`parse_ref_any` accepts it (and
+    the raw 72-hex form) on input.
+    """
+    return hash_to_hex_str(ref[:32]) + '_' + str(struct.unpack('<I', ref[32:36])[0])
+
+
+def parse_ref_any(ref_str: str) -> bytes:
+    """Parse a ref in either supported form into the 36 raw key bytes.
+
+    Accepts both:
+      * 72-hex *internal* form (the raw RocksDB key bytes: internal-order txid +
+        little-endian uint32 vout), and
+      * display ``txid_vout`` form (big-endian txid + decimal vout).
+
+    Returns the 36-byte ref. Raises ``ValueError`` on malformed input so REST
+    handlers can map it to a 400/422.
+    """
+    s = ref_str.strip()
+    sep = '_' if '_' in s else (':' if ':' in s else None)
+    if sep is not None:
+        txid_hex, vout_str = s.rsplit(sep, 1)
+        if len(txid_hex) != 64:
+            raise ValueError('txid_vout form requires a 64-hex txid')
+        return hex_str_to_hash(txid_hex) + struct.pack('<I', int(vout_str))
+    b = bytes.fromhex(s)
+    if len(b) != 36:
+        raise ValueError('ref must be 72 hex chars (36 bytes) or txid_vout form')
+    return b
+
+
 def pack_balance_key(scripthash: bytes, ref: bytes) -> bytes:
     """Pack a balance key."""
     return GlyphDBKeys.BALANCE + scripthash + ref
@@ -87,6 +124,18 @@ def pack_balance_key(scripthash: bytes, ref: bytes) -> bytes:
 def pack_holder_key(ref: bytes, scripthash: bytes) -> bytes:
     """Pack a holder-by-ref key (secondary index for token holder lookups)."""
     return GlyphDBKeys.HOLDER_BY_REF + ref + scripthash
+
+
+def pack_owner_key(hashX: bytes) -> bytes:
+    """Pack an owner-resolution key (hashX -> base scriptPubKey).
+
+    Lets the holder/balance indexes — which are keyed by the one-way 11-byte
+    ``hashX`` — be resolved back to a displayable owner identity (full Electrum
+    scripthash + base58 address).  The indexer saw the output's scriptPubKey at
+    index time, so it persists it here rather than throwing it away; a one-way
+    hash alone could never be reversed.
+    """
+    return GlyphDBKeys.OWNER + hashX
 
 
 def pack_token_key(ref: bytes) -> bytes:
@@ -344,6 +393,10 @@ class GlyphIndex:
         self.balance_cache: Dict[bytes, int] = {}  # key -> amount
         self.balance_height: Dict[bytes, int] = {}
         self.balance_deletes: Set[bytes] = set()  # balance keys to delete from DB on flush
+        # hashX -> base scriptPubKey, for resolving holder rows to a displayable
+        # owner identity (address / full scripthash).  Idempotent: a given hashX
+        # always maps to the same script, so we never need to delete or undo it.
+        self.owner_cache: Dict[bytes, bytes] = {}
         self.history_cache: List[Tuple[int, bytes, bytes]] = []  # (height, key, value)
         self.metadata_cache: Dict[bytes, bytes] = {}  # hash -> cbor
         self.metadata_height: Dict[bytes, int] = {}
@@ -359,7 +412,7 @@ class GlyphIndex:
 
         # In-memory stats delta accumulator (R11)
         # Tracks net change in counts since last flush
-        self._stats_delta: Dict[str, int] = {'total': 0, 'ft': 0, 'nft': 0, 'dat': 0, 'dmint': 0, 'v1': 0, 'v2': 0}
+        self._stats_delta: Dict[str, int] = dict(self._STATS_ZERO)
 
         # Transient set of refs known to exist as tokens (cleared on flush, R14).
         # Prevents redundant DB lookups within a flush window.
@@ -1115,11 +1168,11 @@ class GlyphIndex:
                     token.timelock_cek_hash = tl.get('cek_hash')  # 'sha256:hex'
                     token.timelock_hint = tl.get('hint')
 
-        # Store in cache
+        # Store in cache (GSTAT counting happens once at the GT write point in
+        # flush(), covering all registration paths uniformly).
         self.token_cache[ref] = token
         self.token_height[ref] = height
-        self._update_stats_delta(token, +1)  # R11: increment GSTAT counter
-        
+
         # Add deploy event to history
         history_key = pack_history_key(ref, height, tx_idx)
         history_value = struct.pack('<B', GlyphEventType.DEPLOY) + tx_hash
@@ -1293,7 +1346,11 @@ class GlyphIndex:
         """Process token balance changes for a transaction.
 
         debits:  list of (hashX, value, refs_bytes) for spent inputs
-        credits: list of (hashX, value, refs_dict_keys) for new outputs
+        credits: list of (hashX, value, refs_dict_keys[, base_script]) for new
+                 outputs.  The optional ``base_script`` is the recipient's base
+                 locking script (ref preamble stripped); when present it is
+                 stashed in the owner index so holder rows resolve to a
+                 displayable address.
 
         Only known Glyph tokens are tracked; other refs are ignored.
         """
@@ -1310,10 +1367,20 @@ class GlyphIndex:
                     self.update_balance(height, hashX, ref, -value)
 
         # Credits: add balance for each new output carrying a token ref
-        for hashX, value, ref_keys in credits:
+        for credit in credits:
+            if len(credit) == 4:
+                hashX, value, ref_keys, base_script = credit
+            else:
+                hashX, value, ref_keys = credit
+                base_script = None
+            credited = False
             for ref in ref_keys:
                 if len(ref) == 36 and self._is_known_token(ref):
                     self.update_balance(height, hashX, ref, value)
+                    credited = True
+            # Persist a resolvable owner identity for this hashX (idempotent).
+            if credited and base_script and hashX not in self.owner_cache:
+                self.owner_cache[hashX] = base_script
     
     def _undo_key(self, height: int) -> bytes:
         return GlyphDBKeys.UNDO + pack_be_uint32(height)
@@ -1378,6 +1445,7 @@ class GlyphIndex:
             + len(self.balance_cache) * 140
             + len(self.balance_height) * 140
             + len(self.balance_deletes) * 100
+            + len(self.owner_cache) * 120
             + len(self.history_cache) * 250
             + len(self.metadata_cache) * 600
             + len(self.metadata_height) * 140
@@ -1405,9 +1473,16 @@ class GlyphIndex:
             if height is None:
                 continue
             key = pack_token_key(ref)
+            # Count each distinct token exactly once, here at the single GT
+            # write point — there are several registration paths and counting
+            # at each drifts (the GSTAT total previously undercounted the GT row
+            # set ~2x). A token re-written for a metadata update already exists
+            # in the DB, so it is not recounted.
+            if self.db.utxo_db.get(key) is None:
+                self._update_stats_delta(token, +1)
             self._record_undo(height, key)
             batch.put(key, token.to_bytes())
-            
+
             # Also index by type
             type_key = GlyphDBKeys.BY_TYPE + struct.pack('<B', token.token_type) + ref
             self._record_undo(height, type_key)
@@ -1440,6 +1515,14 @@ class GlyphIndex:
             ref = key[hx_off:hx_off + 36]
             holder_key = pack_holder_key(ref, scripthash)
             batch.put(holder_key, packed)
+
+        # Flush owner-resolution index (hashX -> base scriptPubKey).
+        # Idempotent and append-only: a hashX always maps to the same script, so
+        # no undo is recorded — a stale entry is never read once its holder rows
+        # are gone.  Lets holder rows resolve to a displayable address.
+        for hashX, base_script in self.owner_cache.items():
+            batch.put(pack_owner_key(hashX), base_script)
+        self.owner_cache.clear()
 
         # Delete zero-balance entries from DB (primary + secondary)
         # R1: record undo BEFORE deleting so reorgs can restore zero-balanced entries
@@ -1502,7 +1585,7 @@ class GlyphIndex:
         self.key_reveal_height.clear()         # R2
         self.contract_to_token_cache.clear()   # R6
         self.contract_to_token_height.clear()  # R6
-        self._stats_delta = {'total': 0, 'ft': 0, 'nft': 0, 'dat': 0, 'dmint': 0, 'v1': 0, 'v2': 0}  # R11
+        self._stats_delta = dict(self._STATS_ZERO)  # R11
         self._known_refs.clear()               # R14: clear on every flush
     
     # ========================================================================
@@ -1527,28 +1610,42 @@ class GlyphIndex:
         if not any(self._stats_delta.values()):
             return
         raw = self.db.utxo_db.get(GlyphDBKeys.STATS)
+        current = None
         if raw:
             try:
                 current = cbor2.loads(raw)
             except Exception:
-                current = {'total': 0, 'ft': 0, 'nft': 0, 'dat': 0, 'dmint': 0, 'v1': 0, 'v2': 0}
-        else:
-            current = {'total': 0, 'ft': 0, 'nft': 0, 'dat': 0, 'dmint': 0, 'v1': 0, 'v2': 0}
+                current = None
+        if current is None:
+            current = dict(self._STATS_ZERO)
         for k, delta in self._stats_delta.items():
             current[k] = max(0, current.get(k, 0) + delta)
         batch.put(GlyphDBKeys.STATS, cbor2.dumps(current))
 
+    # All bucket keys tracked in GSTAT; by_type buckets sum to `total`.
+    _STATS_ZERO = {'total': 0, 'ft': 0, 'nft': 0, 'dat': 0, 'dmint': 0,
+                   'wave': 0, 'container': 0, 'authority': 0, 'unknown': 0,
+                   'v1': 0, 'v2': 0}
+
     def _update_stats_delta(self, token: 'GlyphTokenInfo', sign: int):
-        """R11 — Accumulate a +1 or -1 delta for a token's type/version buckets."""
+        """R11 — Accumulate a +1/-1 delta for a token's type/version buckets.
+
+        Every token increments exactly one type bucket so the per-type buckets
+        sum to ``total`` (previously WAVE/Container/Authority/unknown tokens hit
+        ``total`` but no bucket, leaving the two disagreeing).
+        """
         self._stats_delta['total'] += sign
-        if token.token_type == GlyphTokenType.FT:
-            self._stats_delta['ft'] += sign
-        elif token.token_type == GlyphTokenType.NFT:
-            self._stats_delta['nft'] += sign
-        elif token.token_type == GlyphTokenType.DAT:
-            self._stats_delta['dat'] += sign
-        elif token.token_type == GlyphTokenType.DMINT:
-            self._stats_delta['dmint'] += sign
+        tt = token.token_type
+        bucket = {
+            GlyphTokenType.FT: 'ft',
+            GlyphTokenType.NFT: 'nft',
+            GlyphTokenType.DAT: 'dat',
+            GlyphTokenType.DMINT: 'dmint',
+            GlyphTokenType.WAVE: 'wave',
+            GlyphTokenType.CONTAINER: 'container',
+            GlyphTokenType.AUTHORITY: 'authority',
+        }.get(tt, 'unknown')
+        self._stats_delta[bucket] += sign
         if getattr(token, 'glyph_version', 1) == 2:
             self._stats_delta['v2'] += sign
         else:
@@ -1562,7 +1659,8 @@ class GlyphIndex:
         base = {
             'enabled': self.enabled,
             'total_tokens': 0,
-            'by_type': {'FT': 0, 'NFT': 0, 'DAT': 0, 'dMint': 0, 'unknown': 0},
+            'by_type': {'FT': 0, 'NFT': 0, 'DAT': 0, 'dMint': 0,
+                        'WAVE': 0, 'Container': 0, 'Authority': 0, 'unknown': 0},
             'by_version': {'v1': 0, 'v2': 0},
             'cache_size': len(self.token_cache),
         }
@@ -1577,6 +1675,10 @@ class GlyphIndex:
                 base['by_type']['NFT'] = c.get('nft', 0)
                 base['by_type']['DAT'] = c.get('dat', 0)
                 base['by_type']['dMint'] = c.get('dmint', 0)
+                base['by_type']['WAVE'] = c.get('wave', 0)
+                base['by_type']['Container'] = c.get('container', 0)
+                base['by_type']['Authority'] = c.get('authority', 0)
+                base['by_type']['unknown'] = c.get('unknown', 0)
                 base['by_version']['v1'] = c.get('v1', 0)
                 base['by_version']['v2'] = c.get('v2', 0)
             except Exception:
@@ -1613,6 +1715,50 @@ class GlyphIndex:
         if len(scripthash) == 32:
             return scripthash[::-1][:HASHX_LEN]
         return scripthash[:HASHX_LEN]
+
+    def _script_to_address(self, script: bytes) -> Optional[str]:
+        """Best-effort base58 address from a base locking script.
+
+        Matches the standard P2PKH / P2SH byte templates directly (robust and
+        unambiguous); returns ``None`` for anything exotic — the caller still
+        has the full scripthash + raw script to fall back on.
+        """
+        if not script:
+            return None
+        coin = getattr(self.env, 'coin', None)
+        if coin is None:
+            return None
+        try:
+            # P2PKH: OP_DUP OP_HASH160 <push20> OP_EQUALVERIFY OP_CHECKSIG
+            if (len(script) == 25 and script[0] == OpCodes.OP_DUP
+                    and script[1] == OpCodes.OP_HASH160 and script[2] == 0x14
+                    and script[23] == OpCodes.OP_EQUALVERIFY
+                    and script[24] == OpCodes.OP_CHECKSIG):
+                return Base58.encode_check(coin.P2PKH_VERBYTE + script[3:23])
+            # P2SH: OP_HASH160 <push20> OP_EQUAL
+            if (len(script) == 23 and script[0] == OpCodes.OP_HASH160
+                    and script[1] == 0x14 and script[22] == OpCodes.OP_EQUAL):
+                return Base58.encode_check(coin.P2SH_VERBYTES[0] + script[2:22])
+        except (Base58Error, Exception):
+            return None
+        return None
+
+    def _owner_identity(self, hashX: bytes) -> Dict[str, Any]:
+        """Resolve a holder hashX to a displayable owner identity.
+
+        Returns ``{'address', 'scripthash', 'hashX'}``.  ``address`` and the
+        full 32-byte Electrum ``scripthash`` are populated when the owner index
+        (``GO``) has the base scriptPubKey for this hashX (written during
+        indexing / resync); otherwise they are ``None`` and only the one-way
+        ``hashX`` is available.
+        """
+        ident = {'address': None, 'scripthash': None, 'hashX': hashX.hex()}
+        script = self.db.utxo_db.get(pack_owner_key(hashX))
+        if script:
+            # Electrum scripthash convention: sha256(script) reversed.
+            ident['scripthash'] = sha256(script)[::-1].hex()
+            ident['address'] = self._script_to_address(script)
+        return ident
 
     def get_balance(self, scripthash: bytes, ref: bytes) -> int:
         """Get token balance for an address scripthash + token ref."""
@@ -1667,7 +1813,8 @@ class GlyphIndex:
             token = self.get_token(ref)
             if token:
                 results.append({
-                    'ref': hash_to_hex_str(ref[:32]) + '_' + str(struct.unpack('<I', ref[32:36])[0]),
+                    'ref': ref_to_display(ref),
+                    'ref_hex': ref.hex(),
                     'amount': amount,
                     'name': token.name,
                     'ticker': token.ticker,
@@ -1787,7 +1934,8 @@ class GlyphIndex:
         token = self.get_token(ref)
         
         return {
-            'ref': ref.hex(),
+            'ref': ref_to_display(ref),
+            'ref_hex': ref.hex(),
             'name': token.name if token else None,
             'ticker': token.ticker if token else None,
             'total_mints': total_mints,
@@ -1924,8 +2072,9 @@ class GlyphIndex:
         txid, vout = unpack_ref(token.ref)
         
         result = {
-            # Core identity
+            # Core identity (canonical txid_vout + raw 72-hex for round-tripping)
             'ref': hash_to_hex_str(txid) + '_' + str(vout),
+            'ref_hex': token.ref.hex(),
             'protocols': token.protocols,
             'type': token.token_type,
             'type_name': self._type_name(token.token_type),
@@ -2107,8 +2256,13 @@ class GlyphIndex:
         Get token holders for a specific token.
 
         Uses the HOLDER_BY_REF secondary index for efficient lookup:
-        GR + ref + scripthash -> amount
+        GR + ref + hashX -> amount
         Supports cursor-based pagination.
+
+        Each holder is resolved to a displayable owner identity via the owner
+        index (``GO``): ``address`` (base58, when standard), the full 32-byte
+        Electrum ``scripthash``, the internal ``hashX``, and ``amount``.  The
+        legacy ``balance`` field is retained as an alias of ``amount``.
         """
         holders = []
         prefix = GlyphDBKeys.HOLDER_BY_REF + ref
@@ -2122,14 +2276,19 @@ class GlyphIndex:
             if len(holders) >= limit:
                 next_cursor = self._encode_cursor(key)
                 break
-            scripthash = key[len(prefix):len(prefix) + 32]
+            hashX = key[len(prefix):]
+            ident = self._owner_identity(hashX)
             holders.append({
-                'scripthash': scripthash.hex(),
-                'balance': balance,
+                'address': ident['address'],
+                'scripthash': ident['scripthash'],
+                'hashX': ident['hashX'],
+                'amount': balance,
+                'balance': balance,  # legacy alias
             })
 
         return {
-            'ref': ref.hex(),
+            'ref': ref_to_display(ref),
+            'ref_hex': ref.hex(),
             'holders': holders,
             'limit': limit,
             'next_cursor': next_cursor,
@@ -2168,7 +2327,8 @@ class GlyphIndex:
             circulating = token.current_supply
 
         return {
-            'ref': ref.hex(),
+            'ref': ref_to_display(ref),
+            'ref_hex': ref.hex(),
             'name': token.name,
             'ticker': token.ticker,
             'decimals': token.decimals,
@@ -2214,7 +2374,8 @@ class GlyphIndex:
                 })
         
         return {
-            'ref': ref.hex(),
+            'ref': ref_to_display(ref),
+            'ref_hex': ref.hex(),
             'total_burns': total_burns,
             'burns': burns,
             'limit': limit,
@@ -2252,7 +2413,8 @@ class GlyphIndex:
                 })
         
         return {
-            'ref': ref.hex(),
+            'ref': ref_to_display(ref),
+            'ref_hex': ref.hex(),
             'total_trades': total_trades,
             'trades': trades,
             'limit': limit,
@@ -2269,34 +2431,37 @@ class GlyphIndex:
         Uses HOLDER_BY_REF secondary index.
         """
         all_holders = []
-        
+
         prefix = GlyphDBKeys.HOLDER_BY_REF + ref
         for key, value in self.db.utxo_db.iterator(prefix=prefix):
             balance = struct.unpack('<Q', value)[0] if len(value) == 8 else 0
             if balance > 0:
-                scripthash = key[len(prefix):len(prefix)+32]
-                all_holders.append({
-                    'scripthash': scripthash.hex(),
-                    'balance': balance,
-                })
-        
-        # Sort by balance descending
-        all_holders.sort(key=lambda x: x['balance'], reverse=True)
-        
+                hashX = key[len(prefix):]
+                all_holders.append({'hashX': hashX, 'amount': balance})
+
+        # Sort by balance descending, then resolve only the top N to an identity
+        all_holders.sort(key=lambda x: x['amount'], reverse=True)
+
         # Get token info for context
         token = self.get_token(ref)
         total_supply = token.total_supply if token else 0
-        
-        # Add percentage for each holder
-        top_holders = all_holders[:limit]
-        for holder in top_holders:
-            if total_supply > 0:
-                holder['percentage'] = round(holder['balance'] / total_supply * 100, 4)
-            else:
-                holder['percentage'] = 0
-        
+
+        # Resolve + add percentage for the returned page only
+        top_holders = []
+        for h in all_holders[:limit]:
+            ident = self._owner_identity(h['hashX'])
+            top_holders.append({
+                'address': ident['address'],
+                'scripthash': ident['scripthash'],
+                'hashX': ident['hashX'],
+                'amount': h['amount'],
+                'balance': h['amount'],  # legacy alias
+                'percentage': round(h['amount'] / total_supply * 100, 4) if total_supply > 0 else 0,
+            })
+
         return {
-            'ref': ref.hex(),
+            'ref': ref_to_display(ref),
+            'ref_hex': ref.hex(),
             'name': token.name if token else None,
             'ticker': token.ticker if token else None,
             'total_supply': total_supply,
@@ -2304,68 +2469,101 @@ class GlyphIndex:
             'top_holders': top_holders,
         }
     
-    def get_all_tokens_summary(self, limit: int = 100, offset: int = 0, 
-                               token_type: int = None) -> Dict[str, Any]:
-        """
-        Get summary of all indexed tokens with pagination.
-        
-        Optionally filter by token type.
-        """
-        tokens = []
-        total = 0
-        
-        prefix = GlyphDBKeys.TOKEN
-        for key, value in self.db.utxo_db.iterator(prefix=prefix):
-            try:
-                token = GlyphTokenInfo.from_bytes(value)
-                
-                # Filter by type if specified
-                if token_type is not None and token.token_type != token_type:
-                    continue
-                
-                total += 1
-                if total > offset and len(tokens) < limit:
-                    entry = {
-                        'ref': token.ref.hex(),
-                        'name': token.name,
-                        'ticker': token.ticker,
-                        'type': self._type_name(token.token_type),
-                        'type_id': token.token_type,
-                        'glyph_version': token.glyph_version,
-                        'total_supply': token.total_supply,
-                        'current_supply': token.current_supply,
-                        'deploy_height': token.deploy_height,
-                        'is_spent': token.is_spent,
-                        'icon_ref': token.icon_ref,
-                        'icon_type': token.icon_type,
+    # token_type id -> get_stats()['by_type'] bucket name
+    _TYPE_TO_STAT = {
+        GlyphTokenType.FT: 'FT', GlyphTokenType.NFT: 'NFT',
+        GlyphTokenType.DAT: 'DAT', GlyphTokenType.DMINT: 'dMint',
+        GlyphTokenType.WAVE: 'WAVE', GlyphTokenType.CONTAINER: 'Container',
+        GlyphTokenType.AUTHORITY: 'Authority',
+    }
+
+    def _summary_entry(self, token: 'GlyphTokenInfo') -> Dict[str, Any]:
+        """Build a list-summary row for a token (with grid image metadata)."""
+        entry = {
+            'ref': ref_to_display(token.ref),
+            'ref_hex': token.ref.hex(),
+            'name': token.name,
+            'ticker': token.ticker,
+            'type': self._type_name(token.token_type),
+            'type_id': token.token_type,
+            'glyph_version': token.glyph_version,
+            'total_supply': token.total_supply,
+            'current_supply': token.current_supply,
+            'deploy_height': token.deploy_height,
+            'is_spent': token.is_spent,
+            'icon_ref': token.icon_ref,
+            'icon_type': token.icon_type,
+        }
+        # Include embed/remote for image rendering in the grid
+        if token.metadata_hash:
+            raw_meta = self.get_metadata(token.metadata_hash)
+            if raw_meta and isinstance(raw_meta, dict):
+                remote = raw_meta.get('remote') or raw_meta.get('rm')
+                embed = raw_meta.get('embed') or raw_meta.get('em') or raw_meta.get('main')
+                if remote and isinstance(remote, dict):
+                    hs = remote.get('hs')
+                    entry['remote'] = {
+                        'url': remote.get('u') or remote.get('url'),
+                        'type': remote.get('t') or remote.get('type'),
+                        'hash': (remote.get('h') or b'').hex() if isinstance(remote.get('h'), (bytes, bytearray)) else None,
+                        'hashstamp': bytes(hs).hex() if isinstance(hs, (bytes, bytearray)) else None,
                     }
-                    # Include embed/remote for image rendering in the grid
-                    if token.metadata_hash:
-                        raw_meta = self.get_metadata(token.metadata_hash)
-                        if raw_meta and isinstance(raw_meta, dict):
-                            remote = raw_meta.get('remote') or raw_meta.get('rm')
-                            embed = raw_meta.get('embed') or raw_meta.get('em') or raw_meta.get('main')
-                            if remote and isinstance(remote, dict):
-                                hs = remote.get('hs')
-                                entry['remote'] = {
-                                    'url': remote.get('u') or remote.get('url'),
-                                    'type': remote.get('t') or remote.get('type'),
-                                    'hash': (remote.get('h') or b'').hex() if isinstance(remote.get('h'), (bytes, bytearray)) else None,
-                                    'hashstamp': bytes(hs).hex() if isinstance(hs, (bytes, bytearray)) else None,
-                                }
-                            elif embed and isinstance(embed, dict):
-                                b = embed.get('b')
-                                if hasattr(b, 'value'):
-                                    b = bytes.fromhex(b.value) if isinstance(b.value, str) else b.value
-                                entry['embed'] = {
-                                    'type': embed.get('t') or embed.get('type'),
-                                    'size': len(b) if isinstance(b, (bytes, bytearray)) else None,
-                                    'data': bytes(b).hex() if isinstance(b, (bytes, bytearray)) else None,
-                                }
-                    tokens.append(entry)
-            except Exception:
-                continue
-        
+                elif embed and isinstance(embed, dict):
+                    b = embed.get('b')
+                    if hasattr(b, 'value'):
+                        b = bytes.fromhex(b.value) if isinstance(b.value, str) else b.value
+                    entry['embed'] = {
+                        'type': embed.get('t') or embed.get('type'),
+                        'size': len(b) if isinstance(b, (bytes, bytearray)) else None,
+                        'data': bytes(b).hex() if isinstance(b, (bytes, bytearray)) else None,
+                    }
+        return entry
+
+    def get_all_tokens_summary(self, limit: int = 100, offset: int = 0,
+                               token_type: int = None) -> Dict[str, Any]:
+        """Summary of all indexed tokens with pagination.
+
+        ``total`` comes from the O(1) GSTAT counter — never a full keyspace scan.
+        Only the rows on the requested page are CBOR-decoded and have metadata
+        fetched; earlier rows are skipped at the iterator without decoding and we
+        stop as soon as the page is full.  Optionally filter by token type (uses
+        the BY_TYPE secondary index so the scan is bounded to that type).
+        """
+        stats = self.get_stats()
+        tokens = []
+
+        if token_type is None:
+            total = stats.get('total_tokens', 0)
+            prefix = GlyphDBKeys.TOKEN
+            seen = 0
+            for key, value in self.db.utxo_db.iterator(prefix=prefix):
+                if len(tokens) >= limit:
+                    break
+                if seen < offset:
+                    seen += 1
+                    continue
+                seen += 1
+                try:
+                    tokens.append(self._summary_entry(GlyphTokenInfo.from_bytes(value)))
+                except Exception:
+                    continue
+        else:
+            total = stats.get('by_type', {}).get(
+                self._TYPE_TO_STAT.get(token_type, 'unknown'), 0)
+            prefix = GlyphDBKeys.BY_TYPE + struct.pack('<B', token_type)
+            seen = 0
+            for key, _ in self.db.utxo_db.iterator(prefix=prefix):
+                if len(tokens) >= limit:
+                    break
+                if seen < offset:
+                    seen += 1
+                    continue
+                seen += 1
+                ref = key[len(prefix):]
+                token = self.get_token(ref)
+                if token:
+                    tokens.append(self._summary_entry(token))
+
         return {
             'total': total,
             'tokens': tokens,

--- a/electrumx/server/rest_api.py
+++ b/electrumx/server/rest_api.py
@@ -115,6 +115,46 @@ app.add_middleware(
 )
 
 
+# --- Ref / scripthash helpers (defined before any endpoint that references them
+#     as a default param value, since decorators evaluate at import time) -------
+
+# Accepts a ref in either canonical form (72-hex internal, or display txid_vout)
+# and returns the 36 raw key bytes. Length bounds cover both: 72-hex == 72 chars,
+# display == 64 + '_' + 1..10 decimal digits.
+_REF_PATH = Path(..., min_length=66, max_length=80,
+                 description="Token ref — 72-hex (internal) or txid_vout form")
+
+
+def _parse_ref(ref: str) -> bytes:
+    """Parse a path ref in either supported form, or raise HTTP 400."""
+    from electrumx.server.glyph_index import parse_ref_any
+    try:
+        return parse_ref_any(ref)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid ref format")
+
+
+def _resolve_scripthash(ident: str) -> bytes:
+    """Resolve an ownership identifier to a 32-byte Electrum scripthash.
+
+    Accepts either a 64-hex Electrum scripthash (as a wallet computes and as
+    ``blockchain.scripthash.*`` uses) or a base58 address. Raises ValueError on
+    anything else.
+    """
+    from electrumx.lib.hash import sha256
+    s = ident.strip()
+    if len(s) == 64:
+        try:
+            return bytes.fromhex(s)
+        except ValueError:
+            pass
+    coin = getattr(getattr(_glyph_index, 'env', None), 'coin', None)
+    if coin is None:
+        raise ValueError('coin unavailable')
+    # base58 address -> Electrum scripthash (sha256(scriptPubKey) reversed)
+    return sha256(coin.pay_to_address_script(s))[::-1]
+
+
 def _require_api_key(x_api_key: Optional[str] = Header(default=None, alias='X-API-Key')):
     required_key = os.getenv('REST_API_KEY', '').strip()
     if not required_key:
@@ -473,11 +513,12 @@ async def get_block(height: int = Path(..., ge=0)):
 
 
 @app.get("/dmint/contracts/{ref}/icon-debug", tags=["dMint"])
-async def get_dmint_contract_icon_debug(ref: str = Path(..., min_length=72, max_length=72)):
+async def get_dmint_contract_icon_debug(ref: str = _REF_PATH):
     """Debug helper: inspect icon fields for a specific dMint contract."""
     _ensure_dmint()
 
     try:
+        ref = _parse_ref(ref).hex()  # accept 72-hex or txid_vout; normalize
         contract = _dmint_contracts.get_contract(ref)
         if not contract:
             raise HTTPException(status_code=404, detail="Contract not found")
@@ -583,12 +624,12 @@ async def get_glyphs_by_type(
 
 
 @app.get("/glyphs/{ref}", tags=["Glyphs"])
-async def get_glyph(ref: str = Path(..., min_length=72, max_length=72)):
+async def get_glyph(ref: str = _REF_PATH):
     """Get Glyph token by reference (72 hex chars = 36 bytes)."""
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         token = _glyph_index.get_token(ref_bytes)
         if not token:
             raise HTTPException(status_code=404, detail="Token not found")
@@ -604,7 +645,7 @@ async def get_glyph(ref: str = Path(..., min_length=72, max_length=72)):
 
 @app.get("/tokens/{ref}/holders", tags=["Token Analytics"])
 async def get_token_holders(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     limit: int = Query(default=100, le=500),
     cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor from previous response next_cursor"),
 ):
@@ -612,7 +653,7 @@ async def get_token_holders(
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         return _glyph_index.get_token_holders(ref_bytes, limit=limit, cursor=cursor)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
@@ -620,13 +661,38 @@ async def get_token_holders(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@app.get("/addresses/{ident}/glyphs", tags=["Ownership"])
+async def get_address_glyphs(
+    ident: str = Path(..., min_length=1, max_length=128,
+                      description="Electrum scripthash (64 hex) or base58 address"),
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor"),
+):
+    """Forward ownership: Glyph tokens (FT + NFT) held by an address.
+
+    This is the REST equivalent of the ElectrumX ``glyph.list_tokens`` method the
+    game/wallet uses. ``ident`` may be a 64-hex Electrum scripthash (what a wallet
+    computes from its address) or a base58 address. Refs are returned in canonical
+    ``txid_vout`` form.
+    """
+    _ensure_glyph_index()
+    try:
+        sh = _resolve_scripthash(ident)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid scripthash or address")
+    try:
+        return _glyph_index.get_balances_for_scripthash(sh, limit=limit, cursor=cursor)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @app.get("/tokens/{ref}/supply", tags=["Token Analytics"])
-async def get_token_supply(ref: str = Path(..., min_length=72, max_length=72)):
+async def get_token_supply(ref: str = _REF_PATH):
     """Get detailed token supply information."""
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         result = _glyph_index.get_token_supply(ref_bytes)
         if not result:
             raise HTTPException(status_code=404, detail="Token not found")
@@ -641,7 +707,7 @@ async def get_token_supply(ref: str = Path(..., min_length=72, max_length=72)):
 
 @app.get("/tokens/{ref}/burns", tags=["Token Analytics"])
 async def get_token_burns(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0)
 ):
@@ -649,7 +715,7 @@ async def get_token_burns(
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         return _glyph_index.get_token_burns(ref_bytes, limit=limit, offset=offset)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
@@ -659,7 +725,7 @@ async def get_token_burns(
 
 @app.get("/tokens/{ref}/trades", tags=["Token Analytics"])
 async def get_token_trades(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0)
 ):
@@ -667,7 +733,7 @@ async def get_token_trades(
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         return _glyph_index.get_token_trades(ref_bytes, limit=limit, offset=offset)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
@@ -677,14 +743,14 @@ async def get_token_trades(
 
 @app.get("/tokens/{ref}/top-holders", tags=["Token Analytics"])
 async def get_top_token_holders(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     limit: int = Query(default=100, le=500)
 ):
     """Get top token holders (rich list) for a specific token."""
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         return _glyph_index.get_top_holders(ref_bytes, limit=limit)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
@@ -694,7 +760,7 @@ async def get_top_token_holders(
 
 @app.get("/tokens/{ref}/history", tags=["Token Analytics"])
 async def get_token_history(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     limit: int = Query(default=100, le=500),
     offset: int = Query(default=0, ge=0),
     cursor: Optional[str] = Query(default=None),
@@ -709,7 +775,7 @@ async def get_token_history(
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         if cursor is None:
             return _glyph_index.get_token_history(ref_bytes, limit=limit, offset=offset)
         return _glyph_index.get_token_history(
@@ -740,12 +806,12 @@ def _sanitize_cbor(obj):
 
 
 @app.get("/tokens/{ref}/metadata", tags=["Token Analytics"])
-async def get_token_metadata(ref: str = Path(..., min_length=72, max_length=72)):
+async def get_token_metadata(ref: str = _REF_PATH):
     """Get parsed CBOR metadata for a token."""
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         token = _glyph_index.get_token(ref_bytes)
         if not token:
             raise HTTPException(status_code=404, detail="Token not found")
@@ -790,7 +856,7 @@ async def list_encrypted_tokens(
 
 
 @app.get("/glyphs/{ref}/key-reveal", tags=["Encrypted"])
-async def get_key_reveal(ref: str = Path(..., min_length=72, max_length=72)):
+async def get_key_reveal(ref: str = _REF_PATH):
     """
     Get the CEK reveal record for a timelocked token.
 
@@ -799,7 +865,7 @@ async def get_key_reveal(ref: str = Path(..., min_length=72, max_length=72)):
     """
     _ensure_glyph_index()
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         result = _glyph_index.get_key_reveal(ref_bytes)
         if result is None:
             return {"revealed": False}
@@ -812,7 +878,7 @@ async def get_key_reveal(ref: str = Path(..., min_length=72, max_length=72)):
 
 @app.post("/glyphs/{ref}/key-reveal", tags=["Encrypted"])
 async def record_key_reveal(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     reveal_tx: str = Query(..., min_length=64, max_length=64, description="Reveal tx txid (64 hex)"),
     revealed_key: str = Query(..., min_length=64, max_length=64, description="CEK hex (64 hex = 32 bytes)"),
     reveal_height: int = Query(..., ge=0, description="Block height of reveal confirmation"),
@@ -828,7 +894,7 @@ async def record_key_reveal(
         import hashlib
         import time as _time
 
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         cek_bytes = bytes.fromhex(revealed_key)
 
         # Verify CEK hash matches on-chain commitment
@@ -930,11 +996,12 @@ async def get_dmint_contracts(
 
 
 @app.get("/dmint/contracts/{ref}", tags=["dMint"])
-async def get_dmint_contract(ref: str = Path(..., min_length=72, max_length=72)):
+async def get_dmint_contract(ref: str = _REF_PATH):
     """Get details for a specific dMint contract."""
     _ensure_dmint()
 
     try:
+        ref = _parse_ref(ref).hex()  # accept 72-hex or txid_vout; normalize
         contract = _dmint_contracts.get_contract(ref)
         if not contract:
             raise HTTPException(status_code=404, detail="Contract not found")
@@ -1031,12 +1098,13 @@ async def get_dmint_stats():
 
 @app.get("/dmint/contracts/{ref}/daa", tags=["dMint"])
 async def get_dmint_contract_daa(
-    ref: str = Path(..., min_length=72, max_length=72)
+    ref: str = _REF_PATH
 ):
     """Get DAA (Difficulty Adjustment Algorithm) configuration for a specific dMint contract."""
     _ensure_dmint()
 
     try:
+        ref = _parse_ref(ref).hex()  # accept 72-hex or txid_vout; normalize
         contract = _dmint_contracts.get_contract(ref)
         if not contract:
             raise HTTPException(status_code=404, detail="Contract not found")
@@ -1084,7 +1152,7 @@ async def get_dmint_contract_daa(
 
 @app.get("/dmint/contracts/{ref}/mints", tags=["dMint"])
 async def get_dmint_mint_history(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
     limit: int = Query(default=100, le=500),
     offset: int = Query(default=0, ge=0),
 ):
@@ -1092,7 +1160,7 @@ async def get_dmint_mint_history(
     _ensure_glyph_index()
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         return _glyph_index.get_mint_history(ref_bytes, limit=limit, offset=offset)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
@@ -1467,7 +1535,7 @@ def _get_mempool_glyph():
 @app.get("/mempool/glyphs/balance/{scripthash}/{ref}", tags=["Mempool"])
 async def mempool_glyph_balance(
     scripthash: str = Path(..., min_length=64, max_length=64),
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
 ):
     """Get unconfirmed balance delta for a token at an address."""
     mp = _get_mempool_glyph()
@@ -1476,7 +1544,7 @@ async def mempool_glyph_balance(
 
     try:
         sh_bytes = bytes.fromhex(scripthash)
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         delta = mp.get_unconfirmed_glyph_balance(sh_bytes, ref_bytes)
         return {"scripthash": scripthash, "ref": ref, "unconfirmed_delta": delta}
     except ValueError:
@@ -1506,7 +1574,7 @@ async def mempool_glyph_txs(
 
 @app.get("/mempool/glyphs/token/{ref}", tags=["Mempool"])
 async def mempool_token_txs(
-    ref: str = Path(..., min_length=72, max_length=72),
+    ref: str = _REF_PATH,
 ):
     """Get unconfirmed transactions for a specific token."""
     mp = _get_mempool_glyph()
@@ -1514,7 +1582,7 @@ async def mempool_token_txs(
         raise HTTPException(status_code=503, detail="Mempool Glyph indexing not available")
 
     try:
-        ref_bytes = bytes.fromhex(ref)
+        ref_bytes = _parse_ref(ref)
         txs = mp.get_unconfirmed_token_txs(ref_bytes)
         return {"ref": ref, "txs": txs, "count": len(txs)}
     except ValueError:

--- a/tests/server/test_glyph_get_token.py
+++ b/tests/server/test_glyph_get_token.py
@@ -196,7 +196,9 @@ def test_get_by_ref_bad_length():
 
 def test_get_by_ref_bad_hex():
     res = run(FakeSession().glyph_get_by_ref("zz" * 36))  # 72 chars, not hex
-    assert res == {"error": "Invalid hex in ref"}
+    # get_by_ref now accepts both 72-hex and txid_vout, so unparseable input
+    # returns the unified format error.
+    assert res == {"error": "Invalid ref format. Expected 72 hex chars or txid_vout"}
 
 
 def test_get_by_ref_indexing_disabled():

--- a/tests/test_owner_resolution.py
+++ b/tests/test_owner_resolution.py
@@ -222,6 +222,23 @@ def test_glyphs_summary_total_is_o1_and_paginates():
     assert page2['tokens'][0]['ref_hex'] != out['tokens'][0]['ref_hex']
 
 
+def test_base_locking_script_extracts_p2pkh_for_ft_and_nft():
+    """base_locking_script must return the owner P2PKH regardless of where it
+    sits — at the end (NFT, after a ref preamble) or the front (FT, before a
+    state separator + covenant). Otherwise FTs are keyed by the wrong hashX and
+    a wallet can't find them by its address scripthash."""
+    from electrumx.lib.script import Script, ScriptPubKey, OpCodes
+    h160 = bytes(range(20))
+    p2pkh = ScriptPubKey.P2PKH_script(h160)
+    # NFT: OP_PUSHINPUTREFSINGLETON <ref> OP_DROP <P2PKH>
+    nft = bytes([0xd8]) + bytes(36) + bytes([OpCodes.OP_DROP]) + p2pkh
+    # FT: <P2PKH> OP_STATESEPARATOR OP_PUSHINPUTREF <ref> <covenant…>
+    ft = p2pkh + bytes([0xbd, 0xd0]) + bytes(36) + bytes([0xc0, 0xc1, 0x76, 0xa8, 0x88])
+    assert Script.base_locking_script(nft) == p2pkh
+    assert Script.base_locking_script(ft) == p2pkh
+    assert Script.base_locking_script(p2pkh) == p2pkh  # plain script unchanged
+
+
 if __name__ == "__main__":
     import traceback
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]

--- a/tests/test_owner_resolution.py
+++ b/tests/test_owner_resolution.py
@@ -1,0 +1,238 @@
+"""Regression tests for resolvable Glyph holder identity + ref-format helpers.
+
+Covers the P0 owner index (GO: hashX -> base scriptPubKey) and the P2 canonical
+ref parsing/rendering, exercised through the real GlyphIndex methods against a
+fake RocksDB.  No node / regtest required.
+"""
+import struct
+
+from electrumx.lib.coins import Radiant
+from electrumx.lib.hash import sha256, HASHX_LEN, Base58
+from electrumx.lib.script import ScriptPubKey
+from electrumx.server.glyph_index import (
+    GlyphIndex, GlyphDBKeys, pack_holder_key, pack_owner_key,
+    parse_ref_any, ref_to_display,
+)
+
+
+class FakeUtxoDB:
+    """Minimal RocksDB stand-in: a sorted dict supporting get + prefix/seek scan."""
+    def __init__(self):
+        self.d = {}
+
+    def get(self, key):
+        return self.d.get(key)
+
+    def put(self, key, value):
+        self.d[key] = value
+
+    def iterator(self, prefix=b'', seek=None):
+        start = seek if seek is not None else prefix
+        for k in sorted(self.d):
+            if k < start:
+                continue
+            if not k.startswith(prefix):
+                continue
+            yield k, self.d[k]
+
+
+class FakeDB:
+    def __init__(self):
+        self.utxo_db = FakeUtxoDB()
+        self.db_height = 1000
+
+
+class FakeEnv:
+    coin = Radiant
+    glyph_index = True
+    reorg_limit = 0
+
+
+def _make_index():
+    gi = GlyphIndex(FakeDB(), FakeEnv())
+    return gi
+
+
+def _p2pkh(hash160: bytes):
+    """Return (base_script, hashX, electrum_scripthash_hex, address)."""
+    script = ScriptPubKey.P2PKH_script(hash160)
+    digest = sha256(script)
+    hashX = digest[:HASHX_LEN]
+    scripthash_hex = digest[::-1].hex()
+    address = Base58.encode_check(Radiant.P2PKH_VERBYTE + hash160)
+    return script, hashX, scripthash_hex, address
+
+
+def test_parse_ref_any_both_forms_equal():
+    txid_display = "b3d8a9b16e36161f994a83492931140e279b076a0556eab260439a02e25ccf06"
+    raw = parse_ref_any(txid_display + "_0")           # display txid_vout
+    raw2 = parse_ref_any(bytes.fromhex(txid_display)[::-1].hex() + "00000000")  # 72-hex internal
+    assert raw == raw2
+    assert len(raw) == 36
+    # round-trips back to display form
+    assert ref_to_display(raw) == txid_display + "_0"
+
+
+def test_parse_ref_any_rejects_garbage():
+    for bad in ["xyz", "1234", "abcd_", "_5", "zz" * 36]:
+        try:
+            parse_ref_any(bad)
+            raised = False
+        except (ValueError, Exception):
+            raised = True
+        assert raised, f"expected ValueError for {bad!r}"
+
+
+def test_script_to_address_p2pkh():
+    gi = _make_index()
+    hash160 = bytes(range(20))
+    script, _, _, address = _p2pkh(hash160)
+    assert gi._script_to_address(script) == address
+
+
+def test_holders_resolve_to_address():
+    gi = _make_index()
+    ref = bytes(range(36))
+    hash160 = bytes([7]) * 20
+    script, hashX, scripthash_hex, address = _p2pkh(hash160)
+
+    # Index rows as the block processor / flush would write them.
+    gi.db.utxo_db.put(pack_owner_key(hashX), script)
+    gi.db.utxo_db.put(pack_holder_key(ref, hashX), struct.pack('<Q', 5))
+
+    out = gi.get_token_holders(ref)
+    assert len(out['holders']) == 1
+    h = out['holders'][0]
+    assert h['address'] == address
+    assert h['scripthash'] == scripthash_hex
+    assert len(h['scripthash']) == 64           # full 32-byte electrum scripthash
+    assert h['hashX'] == hashX.hex()
+    assert h['amount'] == 5 and h['balance'] == 5
+    assert out['ref'] == ref_to_display(ref)
+    assert out['ref_hex'] == ref.hex()
+
+
+def test_holders_without_owner_index_degrade_gracefully():
+    """Pre-resync rows (no GO entry) still return, with null address/scripthash."""
+    gi = _make_index()
+    ref = bytes(range(36))
+    hashX = bytes([9]) * HASHX_LEN
+    gi.db.utxo_db.put(pack_holder_key(ref, hashX), struct.pack('<Q', 1))
+
+    out = gi.get_token_holders(ref)
+    h = out['holders'][0]
+    assert h['address'] is None
+    assert h['scripthash'] is None
+    assert h['hashX'] == hashX.hex()
+    assert h['amount'] == 1
+
+
+def test_flush_writes_owner_index():
+    """process_balance_changes(credit with base_script) -> flush writes GO + GR."""
+    gi = _make_index()
+    ref = bytes(range(36))
+    hash160 = bytes([3]) * 20
+    script, hashX, scripthash_hex, address = _p2pkh(hash160)
+    # Pretend the token is known so the credit is applied.
+    gi._known_refs.add(ref)
+
+    gi.process_balance_changes(
+        height=10,
+        debits=[],
+        credits=[(hashX, 42, [ref], script)],
+    )
+
+    class FakeBatch:
+        def __init__(self, db): self.db = db
+        def put(self, k, v): self.db.put(k, v)
+        def delete(self, k): self.db.d.pop(k, None)
+
+    gi.flush(FakeBatch(gi.db.utxo_db))
+
+    # GO + GR persisted; holders resolve.
+    assert gi.db.utxo_db.get(pack_owner_key(hashX)) == script
+    out = gi.get_token_holders(ref)
+    assert out['holders'][0]['address'] == address
+    assert out['holders'][0]['amount'] == 42
+
+
+class _FakeBatch:
+    def __init__(self, db): self.db = db
+    def put(self, k, v): self.db.put(k, v)
+    def delete(self, k): self.db.d.pop(k, None)
+
+
+def test_stats_buckets_sum_to_total():
+    """Every token type increments a bucket, so by_type sums to total."""
+    from electrumx.lib.glyph import GlyphTokenType
+
+    class T:
+        def __init__(self, tt, ver=1):
+            self.token_type = tt
+            self.glyph_version = ver
+
+    gi = _make_index()
+    types = [GlyphTokenType.FT, GlyphTokenType.FT, GlyphTokenType.NFT,
+             GlyphTokenType.DAT, GlyphTokenType.DMINT, GlyphTokenType.WAVE,
+             GlyphTokenType.CONTAINER, GlyphTokenType.AUTHORITY, 99]  # 99 -> unknown
+    for tt in types:
+        gi._update_stats_delta(T(tt), +1)
+    gi._flush_stats_counter(_FakeBatch(gi.db.utxo_db))
+
+    stats = gi.get_stats()
+    assert stats['total_tokens'] == len(types)
+    assert sum(stats['by_type'].values()) == stats['total_tokens'], stats['by_type']
+    assert sum(stats['by_version'].values()) == stats['total_tokens']
+    assert stats['by_type']['WAVE'] == 1
+    assert stats['by_type']['unknown'] == 1
+    assert stats['by_type']['FT'] == 2
+
+
+def _make_token(ref, token_type, name=None):
+    from electrumx.server.glyph_index import GlyphTokenInfo
+    t = GlyphTokenInfo()
+    t.ref = ref
+    t.token_type = token_type
+    t.name = name
+    return t
+
+
+def test_glyphs_summary_total_is_o1_and_paginates():
+    """total comes from GSTAT (not a row count); page respects limit/offset."""
+    import cbor2
+    from electrumx.server.glyph_index import GlyphDBKeys, pack_token_key, GlyphTokenInfo
+    from electrumx.lib.glyph import GlyphTokenType
+
+    gi = _make_index()
+    refs = [bytes([i]) + bytes(35) for i in range(5)]
+    for i, ref in enumerate(refs):
+        gi.db.utxo_db.put(pack_token_key(ref), _make_token(ref, GlyphTokenType.NFT, f"t{i}").to_bytes())
+    # GSTAT total deliberately != actual row count, to prove total is read O(1)
+    gi.db.utxo_db.put(GlyphDBKeys.STATS, cbor2.dumps({'total': 9999, 'nft': 9999}))
+
+    out = gi.get_all_tokens_summary(limit=2, offset=0)
+    assert out['total'] == 9999                      # from GSTAT, not a scan
+    assert len(out['tokens']) == 2
+    # canonical ref shape on output
+    assert '_' in out['tokens'][0]['ref']
+    assert len(out['tokens'][0]['ref_hex']) == 72
+
+    page2 = gi.get_all_tokens_summary(limit=2, offset=2)
+    assert len(page2['tokens']) == 2
+    assert page2['tokens'][0]['ref_hex'] != out['tokens'][0]['ref_hex']
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(fns)-failed}/{len(fns)} passed")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## Summary
Fixes Glyph ownership end-to-end so the Glyphworld game (and Photonic Wallet) can reliably answer **"what does address X own"** and **"who owns token Y"** with a **resolvable owner identity**, plus correctness/perf cleanups. Validated end-to-end on the local regtest stack against a real on-chain NFT, over **both** REST and the ElectrumX protocol.

> ⚠️ **Requires a one-time full resync** for full effect on existing mainnet data (the owner index is new, balances were re-keyed to base-address hashX in `a9b90a7`/`b881a43`, and the counter is rebuilt). The code is correct going forward and additive — it runs against the current DB in a degraded mode (null `address`, stale counts) until the resync completes. No schema-version bump, so no forced downtime.

## P0 — resolvable owner identity (the marketplace/provenance ask)
- New **`GO` index** (`hashX → base scriptPubKey`), written at credit time (`block_processor` now threads `base_script` through `process_balance_changes`).
- `/tokens/{ref}/holders` and `/tokens/{ref}/top-holders` now return `{address, scripthash (64-hex), hashX, amount}`. A one-way hash can't be reversed to an address, so we persist the scriptPubKey the indexer already saw. Degrades to `null` address for un-resynced rows.
- `glyph.get_by_ref` gains a resolvable `owner` + `holder_count`.
- Fixed the holder-row slice bug (read the 11-byte hashX, not a phantom 32 bytes).

## P0 — address→tokens forward route
- `GET /addresses/{ident}/glyphs` (accepts a 64-hex Electrum scripthash **or** a base58 address) — the REST twin of the ElectrumX `glyph.list_tokens` the game inventory uses.

## P0 — token counts
- Count each token once at the single `GT` write point in `flush()` (5 registration paths were drifting; `GSTAT` total undercounted ~2×). All token types now bucketed so `by_type` sums to `total`.

## P1 — listing/aggregate perf
- `get_all_tokens_summary`: `total` from the O(1) `GSTAT` counter; early-break pagination; metadata fetched only for the returned page (was a full keyspace scan + CBOR-decode of every row → 35–45 s). Filtered queries use the `BY_TYPE` index.
- `analytics/top-addresses`: bounded heap + page-only address resolution (was a full scan with a random DB read per address → 30 s timeout).

## P2 — canonical refs
- `parse_ref_any()` accepts 72-hex internal **and** display `txid_vout` (and `:`). All `/tokens/{ref}` + `/glyphs/{ref}` inputs accept both; all outputs carry canonical `ref` (`txid_vout`) **and** `ref_hex` (72-hex) so one endpoint's output feeds another.

## Tests
- New `tests/test_owner_resolution.py` (owner resolution → address, ref round-trip both forms, stats buckets sum to total, O(1) `/glyphs` total + pagination).
- Full unit suite: **580 passed, 11 skipped**.

## Regtest validation (real "Radiant Cube" NFT, clean reindex = resync rehearsal)
- `/tokens/{ref}/holders` → `address: moMfswEJUgX3VK6LWBgFvZsXzHHxZHxJ1f`, full 64-hex scripthash, `amount: 1`.
- `/addresses/{scripthash}/glyphs` and `/addresses/{address}/glyphs` → the NFT.
- ElectrumX TCP: `glyph.list_tokens`, `glyph.get_balance`, `glyph.get_by_ref` (owner) all correct.
- Round-trip reconciles: address → scripthash **matches** the holder scripthash.
- `/glyphs/stats` consistent (by_type sums to total); `/glyphs?limit=1` = **0.007 s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)