### PR TITLE
fix(swap): decode RSWP priceTerms (MultiTxOutV1) for real amount + resolvable maker

### DIFF
--- a/electrumx/server/swap_index.py
+++ b/electrumx/server/swap_index.py
@@ -15,9 +15,9 @@ from typing import Optional, Dict, Any, List, Tuple
 from collections import defaultdict
 
 from electrumx.lib import util
-from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash, sha256
+from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash, sha256, Base58, Base58Error
 from electrumx.lib.util import pack_be_uint32, encode_undo, decode_undo
-from electrumx.lib.script import OpCodes
+from electrumx.lib.script import OpCodes, Script, ScriptError
 from electrumx.server.metrics import swap_parse_errors_total as _swap_parse_errors
 
 try:
@@ -415,11 +415,12 @@ class SwapIndex:
             return None
         offered_type = chunks[idx][0]
         idx += 1
-        
-        # Terms type
+
+        # Constant 0x01 marker (Photonic `buildSwapAdvertisementScript` emits a
+        # literal 0x01 push here — it is NOT a terms-type selector. The actual
+        # terms live in the priceTerms MultiTxOutV1 blob below.)
         if len(chunks[idx]) != 1:
             return None
-        terms_type = chunks[idx][0]
         idx += 1
         
         # Token ID (32 bytes)
@@ -458,13 +459,11 @@ class SwapIndex:
         remaining = chunks[idx:]
         if len(remaining) < 2:
             return None
-        
-        # Signature is last push
+
+        # Layout after utxoIndex is exactly: <priceTerms push> <signature push>.
+        price_terms_blob = remaining[0]
         signature = remaining[-1]
-        
-        # Price term pushes are all pushes before the signature
-        price_term_chunks = remaining[:-1]
-        
+
         # Build order
         order.order_id = utxo_hash + struct.pack('<I', utxo_index)
         order.base_ref = token_id + struct.pack('<I', 0)  # Token ref
@@ -472,11 +471,112 @@ class SwapIndex:
             order.quote_ref = want_token_id + struct.pack('<I', 0)
         order.side = OrderSide.SELL if offered_type == 1 else OrderSide.BUY
         order.status = OrderStatus.OPEN
-        
-        # Parse price/amount from price_term_chunks based on termsType
-        self._parse_price_terms(terms_type, price_term_chunks, order)
-        
+
+        # priceTerms is a MultiTxOutV1 blob: the exact payout outputs a taker
+        # must create to fill the order. Decode it for the requested amount and
+        # the resolvable maker (recipient of the payout).
+        self._apply_price_terms(price_terms_blob, order)
+
         return order
+
+    def _parse_multi_txout(self, blob: bytes):
+        """Decode an RSWP MultiTxOutV1 priceTerms blob.
+
+        Layout (see Photonic ``encodePriceTermsOutputs`` / ``parsePriceTerms``):
+            <CompactSize count> { <value: 8-byte LE> <CompactSize scriptLen> <script> }*count
+        Legacy fallback: a bare ``<value:8-LE><script:rest>`` single output.
+        Returns a list of ``(value:int, script:bytes)`` or ``None``.
+        """
+        if not blob:
+            return None
+
+        def read_compact(b, o):
+            n = b[o]
+            if n < 253:
+                return n, o + 1
+            if n == 253:
+                return struct.unpack_from('<H', b, o + 1)[0], o + 3
+            if n == 254:
+                return struct.unpack_from('<I', b, o + 1)[0], o + 5
+            return struct.unpack_from('<Q', b, o + 1)[0], o + 9
+
+        try:
+            outputs = []
+            o = 0
+            count, o = read_compact(blob, o)
+            if count <= 0 or count > 1000:
+                raise ValueError('bad count')
+            for _ in range(count):
+                if o + 8 > len(blob):
+                    raise ValueError('truncated value')
+                value = struct.unpack_from('<Q', blob, o)[0]
+                o += 8
+                slen, o = read_compact(blob, o)
+                if o + slen > len(blob):
+                    raise ValueError('truncated script')
+                outputs.append((value, blob[o:o + slen]))
+                o += slen
+            if o != len(blob) or not outputs:
+                raise ValueError('trailing bytes')
+            return outputs
+        except Exception:
+            # Legacy single-output fallback: value(8 LE) + rest = script
+            if len(blob) >= 9:
+                return [(struct.unpack_from('<Q', blob, 0)[0], blob[8:])]
+            return None
+
+    def _maker_from_script(self, script: bytes):
+        """Resolve a payout output script to (electrum_scripthash_32, address).
+
+        The maker is the recipient of the priceTerms payout; the script is a
+        p2pkh (RXD) or an ftScript (token) that embeds the maker P2PKH. Returns
+        (b'', None) if no standard address can be extracted.
+        """
+        try:
+            base = Script.base_locking_script(script)
+        except (ScriptError, Exception):
+            return b'', None
+        coin = getattr(self.env, 'coin', None)
+        # Standard templates: P2PKH (OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG) / P2SH
+        address = None
+        try:
+            if (len(base) == 25 and base[0] == OpCodes.OP_DUP
+                    and base[1] == OpCodes.OP_HASH160 and base[2] == 0x14
+                    and base[23] == OpCodes.OP_EQUALVERIFY and base[24] == OpCodes.OP_CHECKSIG):
+                if coin is not None:
+                    address = Base58.encode_check(coin.P2PKH_VERBYTE + base[3:23])
+            elif (len(base) == 23 and base[0] == OpCodes.OP_HASH160
+                    and base[1] == 0x14 and base[22] == OpCodes.OP_EQUAL):
+                if coin is not None:
+                    address = Base58.encode_check(coin.P2SH_VERBYTES[0] + base[2:22])
+            else:
+                return b'', None
+        except (Base58Error, Exception):
+            address = None
+        # Electrum scripthash convention: sha256(script) reversed.
+        return sha256(base)[::-1], address
+
+    def _apply_price_terms(self, price_terms_blob: bytes, order: SwapOrderInfo):
+        """Populate amount / price / maker from the priceTerms MultiTxOutV1 blob.
+
+        RSWP orders are fixed-payment swaps (offer this UTXO, pay me these exact
+        outputs), so there is no separate per-unit price: ``amount`` is the total
+        requested payout and ``price`` mirrors it. The maker is the recipient.
+        """
+        outputs = self._parse_multi_txout(price_terms_blob)
+        if not outputs:
+            return
+        total = sum(v for v, _ in outputs)
+        order.amount = total
+        order.remaining_amount = total
+        order.price = total
+        # Maker = recipient of the first standard payout output.
+        for _, out_script in outputs:
+            sh, addr = self._maker_from_script(out_script)
+            if sh:
+                order.maker_scripthash = sh
+                order.maker_address = addr
+                break
     
     def _parse_price_terms(self, terms_type: int, term_chunks: List[bytes],
                            order: SwapOrderInfo):

--- a/tests/test_swap_parse.py
+++ b/tests/test_swap_parse.py
@@ -1,0 +1,97 @@
+"""Regression test for RSWP v2 swap-advertisement parsing.
+
+Decodes the priceTerms MultiTxOutV1 blob (Photonic encoding) so /swaps/orders
+returns the real requested amount and a resolvable maker — instead of the
+price=0/amount=0/maker=null the previous parser produced.
+
+Exercised against a real mainnet order (tx 5fbd060e…, height 428525) over the
+actual RSWP OP_RETURN script — no node/chain needed.
+"""
+from electrumx.lib.coins import Radiant
+from electrumx.server.swap_index import SwapIndex, OrderSide
+
+
+# Real RSWP v2 OP_RETURN scriptPubKey from mainnet order 5fbd060e… vout 0.
+ORDER_SCRIPT_HEX = (
+    "6a0452535750010201010100010120"
+    "0000000000000000000000000000000000000000000000000000000000000000"  # offeredTokenId (zero = RXD)
+    "204f9b4240e9e550191ba05d50f036f0939283c2457a16dccae57dd23b41414932"  # wantTokenId
+    "20d900351899a25a4aea526dc17884059891c798fa9cf6ad2bfc9119797868181b"  # offeredTxid
+    "00"  # offeredVout
+    "4c55"  # OP_PUSHDATA1 85 -> priceTerms (MultiTxOutV1)
+    "0110270000000000004b76a914d1734330f1afe6cd574d7bc5ec792e113a90a12e88ac"
+    "bdd018e54ed487d33ec9ffc09cc05aed8513c6a893e6d19c47224159a04a38830f3700000000dec0e9aa76e378e4a269e69d"
+    "4c6a"  # OP_PUSHDATA1 106 -> signature
+    "47304402203c138413ad81fa0439b9480c19136d142c7a360e3d612c5a9caf11d42da4c027"
+    "02201990700db8d4c88bd56cf0bb34169f67e1e8aab2f34dc0321f3ba7f3552055d3c321"
+    "035c4691a0a46949cee9f698631301634264338a1290708603d0fb8e51dbfa208b"
+)
+
+EXPECT_MAKER_ADDR = "1L6UJfojmZEciBo83yB1cCMASZyQ8zMKuw"
+EXPECT_MAKER_SH = "7c661d65276a2a7b6e3abd85cf8b843d834fc4aeef578d34a4328e33a63c0526"
+
+
+class FakeEnv:
+    coin = Radiant
+    swap_index = True
+    reorg_limit = 0
+
+
+class FakeDB:
+    class utxo_db:
+        @staticmethod
+        def get(k):
+            return None
+    db_height = 433966
+
+
+def _index():
+    return SwapIndex(FakeDB(), FakeEnv())
+
+
+def test_parse_multi_txout_roundtrip():
+    si = _index()
+    # count=1, value=10000 (LE 8B), scriptLen=3, script=aabbcc
+    blob = bytes.fromhex("01" + "1027000000000000" + "03" + "aabbcc")
+    out = si._parse_multi_txout(blob)
+    assert out == [(10000, bytes.fromhex("aabbcc"))]
+
+
+def test_parse_multi_txout_legacy_fallback():
+    si = _index()
+    # not valid MultiTxOut (no sensible count framing) -> legacy [value(8), script(rest)]
+    blob = bytes.fromhex("e803000000000000" + "deadbeef")  # value=1000
+    out = si._parse_multi_txout(blob)
+    assert out and out[0][0] == 1000 and out[0][1] == bytes.fromhex("deadbeef")
+
+
+def test_rswp_v2_order_amount_and_maker():
+    si = _index()
+    script = bytes.fromhex(ORDER_SCRIPT_HEX)
+    order = si._parse_rswp_advertisement(script, b"\x11" * 32, 0, 428525, 1780264931)
+    assert order is not None, "parser returned None"
+    # economic fields now populated from the priceTerms blob (were 0/null before)
+    assert order.amount == 10000, order.amount
+    assert order.price == 10000, order.price
+    assert order.remaining_amount == 10000
+    # resolvable maker (was null)
+    assert order.maker_address == EXPECT_MAKER_ADDR, order.maker_address
+    assert order.maker_scripthash.hex() == EXPECT_MAKER_SH, order.maker_scripthash.hex()
+    # structural fields still correct
+    assert order.base_ref == bytes(36)  # zero ref = native RXD offered
+    assert order.quote_ref[:32].hex() == "4f9b4240e9e550191ba05d50f036f0939283c2457a16dccae57dd23b41414932"
+    # offered_type byte was 0 -> BUY under the (unchanged) side logic
+    assert order.side == OrderSide.BUY
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in fns:
+        try:
+            fn(); print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1; print(f"FAIL {fn.__name__}"); traceback.print_exc()
+    print(f"\n{len(fns)-failed}/{len(fns)} passed")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## Summary
`/swaps/orders` returned `price: 0`, `amount: 0`, `maker_scripthash: null`, `maker_address: null` for every order. The RSWP v2 parser decoded the outer advertisement correctly (order_id, base/quote ref, side) but mis-modelled the **`priceTerms`** payload and never extracted the maker.

I traced the authoritative format to **Photonic-Wallet** (where orders are created/taken): `packages/app/src/pages/Swap.tsx` (`buildSwapAdvertisementScript`, `encodePriceTermsOutputs`) + `packages/app/src/swapBroadcast.ts` (`parsePriceTerms`). Documented in memory `rxindexer_rswp_swap_format`.

## Real on-chain format
```
OP_RETURN "RSWP" 0x02 <flags> <offeredType> 0x01(const) <offeredTokenId·rev>
          [<wantTokenId·rev>] <offeredTxid·rev> <offeredVout> <priceTerms> <signature>
```
`priceTerms` is **one push** holding a **MultiTxOutV1** blob — the exact payout outputs a taker must create (the maker receives them):
```
<CompactSize count> { <value: 8-byte LE> <CompactSize scriptLen> <script> }*count
```

## The 4 bugs fixed (`electrumx/server/swap_index.py`)
1. chunk[5] (a constant `0x01`) was read as `terms_type` — it isn't.
2. `_parse_price_terms` expected separate `[num,denom,amount]` script pushes; the real `priceTerms` is one MultiTxOutV1 push.
3. `_parse_script_int` capped at 4 bytes → 8-byte LE values became 0.
4. `maker_scripthash` was never assigned (the maker P2PKH lives inside the priceTerms script).

## Fix
- Treat chunk[5] as the constant marker (ignore).
- `_parse_multi_txout()` — decode the MultiTxOutV1 blob (+ legacy single-output fallback).
- `_apply_price_terms()` — set `amount`/`remaining_amount`/`price` from the requested payout value (RSWP is fixed-payment, so `price` mirrors the ask).
- `_maker_from_script()` — resolve the payout output's P2PKH/P2SH (via `base_locking_script`) to the full Electrum scripthash + base58 address, so `maker_*` populate and the `OPEN_BY_MAKER` index keys correctly.

## Tests
`tests/test_swap_parse.py` decodes the **real mainnet order 5fbd060e…** (height 428525) end-to-end over its actual RSWP OP_RETURN: `amount`/`price`=**10000**, maker=**`1L6UJfojmZEciBo83yB1cCMASZyQ8zMKuw`**, plus MultiTxOutV1 round-trip + legacy-fallback. Full suite: **584 passed**.

## Deploy note
Applies to all **newly-indexed** orders on deploy (rebuild + restart `rxindexer`, no resync needed). The 2 existing mainnet orders only refresh on a full reindex — not worth a resync for 2 orders; they'll correct at the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)