### PR TITLE
feat(dmint): per-contract liveness for correct burn detection (P1)

### DIFF
--- a/electrumx/server/dmint_contracts.py
+++ b/electrumx/server/dmint_contracts.py
@@ -447,7 +447,20 @@ class DMintContractsManager:
                     or (total_supply > 0 and mined_supply >= total_supply)
                 )
 
-                desired_active = not supply_exhausted
+                # Track per-contract liveness for the API (mineable_remaining).
+                live = token.get('live_contracts')
+                if live is not None and live != existing.get('live_contracts'):
+                    existing['live_contracts'] = live
+                    changed = True
+
+                # Prefer the indexer's authoritative mineability signal (v3:
+                # supply remaining AND >=1 live contract singleton). Fall back to
+                # supply-only when it's None (records predating the v3 reindex)
+                # so pre-v3 data never regresses. This is what re-hides genuinely
+                # burned tokens (all contracts gone, supply remaining) that the
+                # supply-only rule would wrongly show as mineable.
+                mineable = token.get('mineable')
+                desired_active = (not supply_exhausted) if mineable is None else bool(mineable)
                 reactivated = False
                 if bool(existing.get('active', True)) != desired_active:
                     existing['active'] = desired_active
@@ -496,16 +509,20 @@ class DMintContractsManager:
                     deploy_height=token.get('deploy_height', 0),
                 )
                 if added:
-                    # Initial active state from supply (mirrors the existing-
-                    # contract path): a newly-seen fully-mined token is inactive.
+                    # Initial active state: prefer the indexer's authoritative
+                    # mineability (per-contract liveness); fall back to supply
+                    # when untracked (None), mirroring the existing-contract path.
                     n_pct = token.get('percent_mined') or 0
                     n_total = token.get('total_supply') or 0
                     n_mined = token.get('mined_supply') or 0
                     n_exhausted = n_pct >= 100 or (n_total > 0 and n_mined >= n_total)
+                    mineable = token.get('mineable')
+                    n_active = (not n_exhausted) if mineable is None else bool(mineable)
                     # Set extra fields on the newly added contract
                     self.update_contract(
                         ref,
-                        active=not n_exhausted,
+                        active=n_active,
+                        live_contracts=token.get('live_contracts'),
                         daa_mode=dmint.get('daa_mode', 0),
                         daa_mode_name=dmint.get('daa_mode_name', 'Fixed'),
                         icon_type=icon_fields.get('icon_type'),
@@ -616,7 +633,16 @@ class DMintContractsManager:
 
         active = bool(contract.get('active', True))
         fully_mined = (not active) or percent_mined >= 100.0
-        mineable_contracts_remaining = 0 if fully_mined else None
+        # Authoritative live-contract count from the indexer (v3+). Surfaces a
+        # real `mineable_remaining` instead of the legacy null; falls back to
+        # null when untracked (pre-v3 records).
+        live_contracts = contract.get('live_contracts')
+        if fully_mined:
+            mineable_contracts_remaining = 0
+        elif isinstance(live_contracts, int):
+            mineable_contracts_remaining = live_contracts
+        else:
+            mineable_contracts_remaining = None
 
         algorithm_id = self._to_int(contract.get('algorithm'), self.ALGO_SHA256D)
         daa_mode_id = self._to_int(contract.get('daa_mode'), 0)

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -57,7 +57,9 @@ class GlyphDBKeys:
     SCHEMA_VERSION = b'GVER'   # GVER -> uint8 schema version (R21)
 
 
-CURRENT_SCHEMA_VERSION = 2
+# v3: per-dMint-contract liveness (`live_contracts`) for correct burn detection.
+# Requires a full reindex to backfill the live-contract set for existing tokens.
+CURRENT_SCHEMA_VERSION = 3
 
 
 # History event types
@@ -168,6 +170,7 @@ class GlyphTokenInfo:
         # dMint specific
         'contract_ref', 'algorithm', 'start_difficulty', 'current_difficulty',
         'reward', 'halving_interval', 'daa_mode', 'mint_count', 'num_contracts',
+        'live_contracts',  # unspent contract singletons; None = untracked (pre-v3 reindex)
         # Relationships
         'container_ref', 'authority_ref', 'parent_ref',
         # NFT specific
@@ -216,7 +219,13 @@ class GlyphTokenInfo:
         self.halving_interval = 0  # Blocks between halvings
         self.daa_mode = 0  # Difficulty adjustment algorithm
         self.mint_count = 0  # Number of mint transactions
-        self.num_contracts = 0  # Number of parallel mining contracts
+        self.num_contracts = 0  # Number of parallel mining contracts (at deploy)
+        # Count of contract singletons still live (unspent). Starts at
+        # num_contracts on deploy and decrements as contracts terminate
+        # (mined out at maxHeight) or are burned. None = not yet tracked
+        # (records written before the v3 reindex) — consumers must treat None
+        # as "unknown" and fall back to supply-only mineability.
+        self.live_contracts = None
         # Relationships
         self.container_ref = None  # Parent container (if contained)
         self.authority_ref = None  # Authority token reference
@@ -299,6 +308,11 @@ class GlyphTokenInfo:
         }
         # Remove None values to save space
         data = {k: v for k, v in data.items() if v is not None and v != 0 and v != b''}
+        # live_contracts: preserve an explicit 0 (= no live contracts / burned or
+        # fully mined), which the zero-strip above would drop. None = untracked
+        # (pre-v3) → omit so it reads back as None.
+        if self.live_contracts is not None:
+            data['lc'] = self.live_contracts
         return cbor2.dumps(data)
     
     @classmethod
@@ -346,6 +360,7 @@ class GlyphTokenInfo:
         info.daa_mode = d.get('da', 0)
         info.mint_count = d.get('mc', 0)
         info.num_contracts = d.get('nc', 0)
+        info.live_contracts = d.get('lc')  # None if absent (untracked / pre-v3)
         # Relationships
         info.container_ref = d.get('co')
         info.authority_ref = d.get('ar')
@@ -372,6 +387,26 @@ class GlyphTokenInfo:
         if self.total_supply == 0:
             return 0.0
         return (self.mined_supply / self.total_supply) * 100.0
+
+    def is_fully_mined(self) -> bool:
+        """All supply mined out (the legitimate 'done' state)."""
+        return self.total_supply > 0 and self.mined_supply >= self.total_supply
+
+    def dmint_mineable(self) -> Optional[bool]:
+        """Whether this dMint token can still be mined.
+
+        Returns:
+            True  — supply remains AND >= 1 live contract singleton.
+            False — fully mined, OR all contracts gone with supply remaining
+                    (burned/terminated early).
+            None  — liveness not tracked (record predates the v3 reindex);
+                    callers should fall back to supply-only mineability.
+        """
+        if self.is_fully_mined():
+            return False
+        if self.live_contracts is None:
+            return None
+        return self.live_contracts > 0
 
 
 class GlyphIndex:
@@ -825,7 +860,31 @@ class GlyphIndex:
                     # Found a singleton ref that is not the token ref — contract ref
                     return ref_bytes.hex()
         return None
-    
+
+    def _find_all_contract_refs(self, tx: 'Tx', token_ref: bytes) -> set:
+        """
+        Find ALL per-contract singleton refs in a dMint deploy.
+
+        Each parallel mining contract output carries a distinct singleton
+        (OP_PUSHINPUTREFSINGLETON 0xd8).  The genuine per-contract singletons
+        share the TOKEN ref's txid (token ref = `GEN:0`, contracts = `GEN:1..N`);
+        the contract covenant also pushes unrelated state singletons at *other*
+        txids, which must be excluded (verified on-chain — see
+        docs/DMINT_BURN_DETECTION_SCOPE.md). Filter:
+            singleton AND ref != token_ref AND ref.txid == token_ref.txid.
+
+        Returns a set of 36-byte contract refs (may be empty).
+        """
+        token_txid = token_ref[:32]
+        found = set()
+        for output in tx.outputs:
+            for ref_bytes, ref_type in self._extract_refs_from_script(output.pk_script):
+                if (ref_type == 1
+                        and ref_bytes != token_ref
+                        and ref_bytes[:32] == token_txid):
+                    found.add(ref_bytes)
+        return found
+
     def _parse_deploy_contract_state(self, token: 'GlyphTokenInfo', tx: 'Tx'):
         """
         Parse initial contract state from the deploy transaction's outputs.
@@ -988,12 +1047,18 @@ class GlyphIndex:
                                tx_idx: int, singleton_ref: bytes):
         """
         Handle a destroyed dMint contract singleton.
-        
+
         Called when a singleton ref was spent in inputs but NOT recreated in
-        any output — the contract UTXO is permanently destroyed.
-        
-        Finds the dMint token that owns this contract ref and marks it as
-        burned (is_spent=True), records a BURN event in history.
+        any output — that one contract UTXO is permanently gone, either because
+        it was mined out at maxHeight (normal completion) or burned (e.g. to an
+        OP_RETURN output).
+
+        Decrements the owning token's `live_contracts` count. It does NOT mark
+        the whole token `is_spent`: a dMint token has `num_contracts` parallel
+        contracts and the others may still be mineable. (The previous behaviour
+        — marking the whole token spent on the first destroyed singleton — hid
+        partially-mined tokens like GRASS, which was 75.9% mined with ~5 live
+        contracts when its first contract completed.)
         """
         token_ref = None
         token = None
@@ -1009,25 +1074,32 @@ class GlyphIndex:
             token_ref = self.contract_to_token_cache.get(singleton_ref)
             if token_ref:
                 token = self.token_cache.get(token_ref) or self.get_token(token_ref)
-        
+
         if token is None or token_ref is None:
             return  # Singleton doesn't belong to a known dMint token
-        
-        if token.is_spent:
-            return  # Already marked
-        
-        token.is_spent = True
+
+        if token.live_contracts is None:
+            # Record predates the v3 reindex — liveness untracked; can't safely
+            # decrement. (A reindex registers every contract and re-runs this.)
+            return
+        if token.live_contracts <= 0:
+            return  # Already fully accounted for
+
+        token.live_contracts -= 1
         self.token_cache[token_ref] = token
         self.token_height[token_ref] = height
-        
-        # Record BURN event in history
+
+        # Record contract-BURN event in history (one per destroyed contract)
         history_key = pack_history_key(token_ref, height, tx_idx)
         history_value = struct.pack('<B', GlyphEventType.BURN) + tx_hash
         self.history_cache.append((height, history_key, history_value))
-        
+
+        remaining = token.live_contracts
+        terminated = remaining == 0 and not token.is_fully_mined()
         self.logger.info(
-            f'dMint CONTRACT BURNED: token={hash_to_hex_str(token_ref[:32])} '
-            f'contract={singleton_ref.hex()[:32]}... height={height}'
+            f'dMint contract gone: token={hash_to_hex_str(token_ref[:32])} '
+            f'contract={singleton_ref.hex()[:32]}... live_contracts={remaining}'
+            f'{" (token TERMINATED early)" if terminated else ""} height={height}'
         )
     
     def _index_token_reveal(self, ref: bytes, tx_hash: bytes, vout_or_vin,
@@ -1089,19 +1161,21 @@ class GlyphIndex:
                 token.reward = dmint_info.get('reward', 0) or 0
                 token.daa_mode = dmint_info.get('daa_mode', 0) or 0
                 token.halving_interval = dmint_info.get('halflife', 0) or 0
-                # Find the contract ref from the deploy tx outputs.
-                # The contract UTXO uses OP_PUSHINPUTREFSINGLETON (0xd8) with a
-                # ref that is different from the token ref (which uses 0xd0).
-                contract_ref_hex = self._find_contract_ref(tx, ref)
-                token.contract_ref = contract_ref_hex
-                # R6: write GC reverse index (contract_ref -> token_ref)
-                if contract_ref_hex:
-                    try:
-                        contract_ref_bytes = bytes.fromhex(contract_ref_hex)
-                        self.contract_to_token_cache[contract_ref_bytes] = ref
-                        self.contract_to_token_height[contract_ref_bytes] = height
-                    except ValueError:
-                        pass
+                # Find ALL per-contract singleton refs from the deploy tx.
+                # Each parallel mining contract is a distinct singleton (0xd8)
+                # sharing the token ref's txid. We register every one so burn
+                # detection can track them individually (live_contracts), rather
+                # than collapsing a multi-contract token to a single ref.
+                contract_refs = self._find_all_contract_refs(tx, ref)
+                # contract_ref keeps the first (sorted, for deterministic display)
+                token.contract_ref = (
+                    sorted(contract_refs)[0].hex() if contract_refs else None
+                )
+                token.live_contracts = len(contract_refs)
+                # R6: write GC reverse index (contract_ref -> token_ref) for each
+                for contract_ref_bytes in contract_refs:
+                    self.contract_to_token_cache[contract_ref_bytes] = ref
+                    self.contract_to_token_height[contract_ref_bytes] = height
                 # Also try to parse initial state from the contract output
                 self._parse_deploy_contract_state(token, tx)
             else:
@@ -2089,6 +2163,12 @@ class GlyphIndex:
             'deploy_txid': hash_to_hex_str(token.deploy_txid) if token.deploy_txid else None,
             'metadata_hash': hash_to_hex_str(token.metadata_hash) if token.metadata_hash else None,
             'is_spent': token.is_spent,
+            # dMint liveness — `mineable` is the authoritative signal the dMint
+            # contracts manager gates on (None = untracked pre-v3 → fall back to
+            # supply). live_contracts = unspent contract singletons.
+            'live_contracts': token.live_contracts,
+            'mineable': (token.dmint_mineable()
+                         if GlyphProtocol.GLYPH_DMINT in token.protocols else None),
             # Supply tracking
             'total_supply': token.total_supply,
             'current_supply': token.current_supply,
@@ -2160,6 +2240,7 @@ class GlyphIndex:
                 'daa_mode_name': self._daa_mode_name(token.daa_mode),
                 'mint_count': token.mint_count,
                 'num_contracts': token.num_contracts,
+                'live_contracts': token.live_contracts,
             }
         
         # Include NFT attributes

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -1089,18 +1089,28 @@ class GlyphIndex:
         self.token_cache[token_ref] = token
         self.token_height[token_ref] = height
 
-        # Record contract-BURN event in history (one per destroyed contract)
-        history_key = pack_history_key(token_ref, height, tx_idx)
-        history_value = struct.pack('<B', GlyphEventType.BURN) + tx_hash
-        self.history_cache.append((height, history_key, history_value))
-
         remaining = token.live_contracts
-        terminated = remaining == 0 and not token.is_fully_mined()
-        self.logger.info(
-            f'dMint contract gone: token={hash_to_hex_str(token_ref[:32])} '
-            f'contract={singleton_ref.hex()[:32]}... live_contracts={remaining}'
-            f'{" (token TERMINATED early)" if terminated else ""} height={height}'
-        )
+        # Emit a single token-level BURN history event ONLY when the token is
+        # genuinely terminated early — all contracts gone with supply still
+        # unmined. Normal per-contract completion (other contracts remain, or
+        # the token ends fully mined) is NOT a burn; emitting one event per
+        # destroyed contract would inflate burned_count / get_token_burns for
+        # healthy fully-mined tokens. This preserves the prior 0/1 semantics
+        # (1 = the token was abandoned/terminated early).
+        if remaining == 0 and not token.is_fully_mined():
+            history_key = pack_history_key(token_ref, height, tx_idx)
+            history_value = struct.pack('<B', GlyphEventType.BURN) + tx_hash
+            self.history_cache.append((height, history_key, history_value))
+            self.logger.info(
+                f'dMint token TERMINATED early (all contracts gone, '
+                f'{token.mined_supply}/{token.total_supply} mined): '
+                f'token={hash_to_hex_str(token_ref[:32])} height={height}'
+            )
+        else:
+            self.logger.debug(
+                f'dMint contract gone: token={hash_to_hex_str(token_ref[:32])} '
+                f'live_contracts={remaining} height={height}'
+            )
     
     def _index_token_reveal(self, ref: bytes, tx_hash: bytes, vout_or_vin,
                             height: int, tx_idx: int, envelope: Dict,
@@ -2039,8 +2049,14 @@ class GlyphIndex:
             token = self.get_token(ref)
             if not token:
                 continue
-            if active_only and token.is_spent:
-                continue
+            if active_only:
+                # Exclude not-mineable tokens (fully mined OR burned). For
+                # records predating the v3 reindex, dmint_mineable() is None —
+                # fall back to the is_spent flag so behaviour is unchanged until
+                # the reindex backfills live_contracts.
+                m = token.dmint_mineable()
+                if m is False or (m is None and token.is_spent):
+                    continue
             if len(tokens) >= limit:
                 next_cursor = self._encode_cursor(key)
                 break

--- a/tests/server/test_dmint_contracts.py
+++ b/tests/server/test_dmint_contracts.py
@@ -422,3 +422,81 @@ def test_sync_from_index_normalizes_embedded_icon_data(tmp_path):
 
     response = mgr.get_contracts_v2({"version": 2, "view": "token_summary", "filters": {"status": "all"}})
     assert response["items"][0]["icon"]["data_hex"] == "aabbccdd"
+
+
+def _dmint_token(ref_internal, *, total_supply, mined_supply, percent_mined,
+                 mineable=None, live_contracts=None, is_spent=False):
+    """GlyphIndex dMint token dict (as get_tokens_by_type returns)."""
+    return {
+        "ref": ref_internal, "ticker": "TKN", "name": "Token",
+        "deploy_height": 300000, "total_supply": total_supply,
+        "mined_supply": mined_supply, "percent_mined": percent_mined,
+        "is_spent": is_spent, "mineable": mineable, "live_contracts": live_contracts,
+        "dmint": {"algorithm": 0, "current_difficulty": 1, "reward": 100,
+                  "num_contracts": 4, "daa_mode": 0, "daa_mode_name": "Fixed"},
+    }
+
+
+def test_manager_hides_burned_token_via_mineable_false(tmp_path):
+    """A token the indexer reports mineable=False (all contracts gone, supply
+    remaining) is listed inactive — restoring burn-hiding that supply-only loses."""
+    gi = Mock()
+    gi.get_tokens_by_type.return_value = [
+        _dmint_token("a" * 64 + "_0", total_supply=1000, mined_supply=400,
+                     percent_mined=40, mineable=False, live_contracts=0)
+    ]
+    mgr = DMintContractsManager(str(tmp_path), glyph_index=gi)
+    mgr.sync_from_index(434000)
+    assert mgr.contracts[0]["active"] is False
+    # Not in the mineable listing
+    resp = mgr.get_contracts_v2({"version": 2, "view": "token_summary"})
+    assert resp["count"] == 0
+
+
+def test_manager_lists_live_token_via_mineable_true(tmp_path):
+    gi = Mock()
+    gi.get_tokens_by_type.return_value = [
+        _dmint_token("b" * 64 + "_0", total_supply=1000, mined_supply=400,
+                     percent_mined=40, mineable=True, live_contracts=3)
+    ]
+    mgr = DMintContractsManager(str(tmp_path), glyph_index=gi)
+    mgr.sync_from_index(434000)
+    assert mgr.contracts[0]["active"] is True
+    assert mgr.contracts[0]["live_contracts"] == 3
+    # mineable_remaining surfaced from live_contracts
+    resp = mgr.get_contracts_v2({"version": 2, "view": "token_summary"})
+    assert resp["count"] == 1
+    assert resp["items"][0]["contracts"]["mineable_remaining"] == 3
+
+
+def test_manager_supply_fallback_when_mineable_untracked(tmp_path):
+    """Pre-v3 records (mineable=None) must not regress: supply-only decides."""
+    gi = Mock()
+    gi.get_tokens_by_type.return_value = [
+        _dmint_token("c" * 64 + "_0", total_supply=1000, mined_supply=400,
+                     percent_mined=40, mineable=None, live_contracts=None,
+                     is_spent=True)  # is_spent must NOT hide it
+    ]
+    mgr = DMintContractsManager(str(tmp_path), glyph_index=gi)
+    mgr.sync_from_index(434000)
+    assert mgr.contracts[0]["active"] is True
+
+
+def test_manager_reactivates_then_burn_hides_on_mineable_flip(tmp_path):
+    """An existing active contract flips inactive once the indexer reports
+    mineable=False (e.g. its last contract was burned)."""
+    gi = Mock()
+    gi.get_tokens_by_type.return_value = [
+        _dmint_token("d" * 64 + "_0", total_supply=1000, mined_supply=400,
+                     percent_mined=40, mineable=False, live_contracts=0)
+    ]
+    mgr = DMintContractsManager(str(tmp_path), glyph_index=gi)
+    mgr.contracts = [{
+        "ref": "d" * 64 + "0", "outputs": 4, "ticker": "TKN", "name": "",
+        "algorithm": 0, "difficulty": 1, "reward": 100, "percent_mined": 40,
+        "active": True, "deploy_height": 300000,
+        "total_supply": 1000, "mined_supply": 400,
+    }]
+    mgr.sync_from_index(434000)
+    assert mgr.contracts[0]["active"] is False
+    assert mgr.contracts[0]["live_contracts"] == 0

--- a/tests/server/test_glyph_index.py
+++ b/tests/server/test_glyph_index.py
@@ -1250,15 +1250,99 @@ class TestBurnDetection:
         tx_hash = b'\xcc' * 32
         index._process_contract_burn(tx_hash, 500, 0, singleton_ref)
 
-        # One contract destroyed → live_contracts decremented, token NOT marked
-        # spent (other contracts may still be mineable).
+        # One of three contracts destroyed → live_contracts decremented, token
+        # NOT marked spent (others may still be mineable), and NO BURN event yet
+        # (normal per-contract completion is not a token burn).
         assert index.token_cache[token_ref].live_contracts == 2
         assert index.token_cache[token_ref].is_spent is False
-        # BURN event recorded
+        assert len(index.history_cache) == 0
+
+    def test_process_contract_burn_emits_burn_only_on_early_termination(self):
+        """A token-level BURN event fires only when the LAST contract is
+        destroyed with supply remaining (genuinely terminated early) — not on
+        each contract completion (keeps burned_count at 0/1)."""
+        from electrumx.server.glyph_index import GlyphIndex, GlyphTokenInfo, GlyphEventType
+        from electrumx.lib.glyph import GlyphProtocol, GlyphTokenType
+
+        mock_db = MagicMock()
+        mock_db.utxo_db = MagicMock()
+        mock_db.utxo_db.get.return_value = None
+        mock_db.db_height = 100
+
+        index = GlyphIndex.__new__(GlyphIndex)
+        index.db = mock_db
+        index.logger = MagicMock()
+        index.enabled = True
+        index.token_cache = {}
+        index.token_height = {}
+        index.history_cache = []
+        index._known_refs = set()
+        index.contract_to_token_cache = {}
+
+        token_ref = b'\xaa' * 36
+        singleton_ref = b'\xbb' * 36
+        token = GlyphTokenInfo()
+        token.ref = token_ref
+        token.protocols = [GlyphProtocol.GLYPH_FT, GlyphProtocol.GLYPH_DMINT]
+        token.token_type = GlyphTokenType.DMINT
+        token.is_spent = False
+        token.total_supply = 1000
+        token.mined_supply = 400          # supply remaining → early termination
+        token.live_contracts = 1          # last live contract
+        token.deploy_txid = b'\x00' * 32
+        index.token_cache[token_ref] = token
+        index.contract_to_token_cache[singleton_ref] = token_ref
+
+        tx_hash = b'\xcc' * 32
+        index._process_contract_burn(tx_hash, 500, 0, singleton_ref)
+
+        assert index.token_cache[token_ref].live_contracts == 0
+        assert index.token_cache[token_ref].is_spent is False  # not fully mined
+        # Exactly one token-level BURN event
         assert len(index.history_cache) == 1
         _, _, history_value = index.history_cache[0]
         assert history_value[0] == GlyphEventType.BURN
         assert history_value[1:33] == tx_hash
+
+    def test_fully_mined_contract_completion_emits_no_burn(self):
+        """The last contract finishing on a FULLY-mined token is a completion,
+        not a burn — no BURN event (so burned_count stays 0)."""
+        from electrumx.server.glyph_index import GlyphIndex, GlyphTokenInfo
+        from electrumx.lib.glyph import GlyphProtocol, GlyphTokenType
+
+        mock_db = MagicMock()
+        mock_db.utxo_db = MagicMock()
+        mock_db.utxo_db.get.return_value = None
+        mock_db.db_height = 100
+
+        index = GlyphIndex.__new__(GlyphIndex)
+        index.db = mock_db
+        index.logger = MagicMock()
+        index.enabled = True
+        index.token_cache = {}
+        index.token_height = {}
+        index.history_cache = []
+        index._known_refs = set()
+        index.contract_to_token_cache = {}
+
+        token_ref = b'\xaa' * 36
+        singleton_ref = b'\xbb' * 36
+        token = GlyphTokenInfo()
+        token.ref = token_ref
+        token.protocols = [GlyphProtocol.GLYPH_FT, GlyphProtocol.GLYPH_DMINT]
+        token.token_type = GlyphTokenType.DMINT
+        token.is_spent = True             # fully mined
+        token.total_supply = 1000
+        token.mined_supply = 1000
+        token.live_contracts = 1
+        token.deploy_txid = b'\x00' * 32
+        index.token_cache[token_ref] = token
+        index.contract_to_token_cache[singleton_ref] = token_ref
+
+        index._process_contract_burn(b'\xcc' * 32, 500, 0, singleton_ref)
+
+        assert index.token_cache[token_ref].live_contracts == 0
+        assert len(index.history_cache) == 0  # completion, not a burn
 
     def test_process_contract_burn_ignores_unknown_singleton(self):
         """_process_contract_burn is a no-op for singletons not owned by any dMint token."""

--- a/tests/server/test_glyph_index.py
+++ b/tests/server/test_glyph_index.py
@@ -1207,8 +1207,9 @@ class TestTokenToDictImages:
 class TestBurnDetection:
     """Tests for dMint contract burn detection and deactivation."""
 
-    def test_process_contract_burn_marks_token_spent(self):
-        """_process_contract_burn sets is_spent=True and records BURN event."""
+    def test_process_contract_burn_decrements_live_contracts(self):
+        """_process_contract_burn decrements live_contracts (not whole-token
+        is_spent) and records a BURN event."""
         from electrumx.server.glyph_index import GlyphIndex, GlyphTokenInfo, GlyphEventType
         from electrumx.lib.glyph import GlyphProtocol, GlyphTokenType
 
@@ -1232,7 +1233,7 @@ class TestBurnDetection:
         index._undo_seen = {}
         index.contract_to_token_cache = {}
 
-        # Create a dMint token with a known contract_ref
+        # Create a multi-contract dMint token (3 live contracts)
         token_ref = b'\xaa' * 36
         singleton_ref = b'\xbb' * 36
         token = GlyphTokenInfo()
@@ -1241,6 +1242,7 @@ class TestBurnDetection:
         token.token_type = GlyphTokenType.DMINT
         token.contract_ref = singleton_ref.hex()
         token.is_spent = False
+        token.live_contracts = 3
         token.deploy_txid = b'\x00' * 32
         index.token_cache[token_ref] = token
         index.contract_to_token_cache[singleton_ref] = token_ref
@@ -1248,8 +1250,10 @@ class TestBurnDetection:
         tx_hash = b'\xcc' * 32
         index._process_contract_burn(tx_hash, 500, 0, singleton_ref)
 
-        # Token should be marked spent
-        assert index.token_cache[token_ref].is_spent is True
+        # One contract destroyed → live_contracts decremented, token NOT marked
+        # spent (other contracts may still be mineable).
+        assert index.token_cache[token_ref].live_contracts == 2
+        assert index.token_cache[token_ref].is_spent is False
         # BURN event recorded
         assert len(index.history_cache) == 1
         _, _, history_value = index.history_cache[0]
@@ -1578,3 +1582,76 @@ class TestSubscriptionCallbackWiring:
         asyncio.run(mgr.notify_balance_change(sh, ref, 100, 10))
         asyncio.run(mgr.notify_token_change(ref, {'name': 'test'}))
         asyncio.run(mgr.notify_transfer(ref, b'\xcc' * 32, sh, sh, 50, 1000))
+
+
+class TestDmintLiveContracts:
+    """P1 — per-contract liveness for correct dMint burn detection."""
+
+    def _token(self):
+        from electrumx.server.glyph_index import GlyphTokenInfo
+        from electrumx.lib.glyph import GlyphProtocol, GlyphTokenType
+        t = GlyphTokenInfo()
+        t.ref = b'\xaa' * 36
+        t.protocols = [GlyphProtocol.GLYPH_FT, GlyphProtocol.GLYPH_DMINT]
+        t.token_type = GlyphTokenType.DMINT
+        return t
+
+    def test_serialization_roundtrip_live_contracts(self):
+        from electrumx.server.glyph_index import GlyphTokenInfo
+        for val in (None, 0, 5, 21):
+            t = self._token()
+            t.live_contracts = val
+            back = GlyphTokenInfo.from_bytes(t.to_bytes())
+            assert back.live_contracts == val, f'roundtrip failed for {val!r}'
+
+    def test_serialization_zero_preserved_not_stripped(self):
+        # 0 must survive (it means "no live contracts"), distinct from None.
+        from electrumx.server.glyph_index import GlyphTokenInfo
+        t = self._token(); t.live_contracts = 0
+        assert GlyphTokenInfo.from_bytes(t.to_bytes()).live_contracts == 0
+        t2 = self._token()  # never set
+        assert GlyphTokenInfo.from_bytes(t2.to_bytes()).live_contracts is None
+
+    def test_dmint_mineable_semantics(self):
+        t = self._token()
+        t.total_supply = 1000
+
+        # untracked → None (caller falls back to supply)
+        t.live_contracts = None; t.mined_supply = 100
+        assert t.dmint_mineable() is None
+
+        # live contracts + supply remaining → mineable
+        t.live_contracts = 5
+        assert t.dmint_mineable() is True
+
+        # all contracts gone, supply remains → burned/terminated → not mineable
+        t.live_contracts = 0
+        assert t.dmint_mineable() is False
+
+        # fully mined → not mineable regardless of live count
+        t.mined_supply = 1000; t.live_contracts = 3
+        assert t.dmint_mineable() is False
+
+    def test_find_all_contract_refs_filters_to_token_txid(self):
+        from electrumx.server.glyph_index import GlyphIndex
+        idx = GlyphIndex.__new__(GlyphIndex)
+        gen = b'\x11' * 32
+        token_ref = gen + (0).to_bytes(4, 'little')          # GEN:0
+        c1 = gen + (1).to_bytes(4, 'little')                 # GEN:1 contract
+        c2 = gen + (2).to_bytes(4, 'little')                 # GEN:2 contract
+        covenant = b'\x22' * 32 + (9).to_bytes(4, 'little')  # singleton, other txid
+        scripts = {
+            b's0': [(c1, 1), (token_ref, 0), (covenant, 1)],
+            b's1': [(c2, 1), (token_ref, 0), (covenant, 1)],
+        }
+        idx._extract_refs_from_script = lambda s: scripts[s]
+
+        class _O:
+            def __init__(self, pk): self.pk_script = pk
+
+        class _T:
+            outputs = [_O(b's0'), _O(b's1')]
+
+        refs = idx._find_all_contract_refs(_T(), token_ref)
+        # GEN:1 and GEN:2 kept; token ref and the other-txid covenant excluded.
+        assert refs == {c1, c2}

--- a/tests/server/test_reorg_undo.py
+++ b/tests/server/test_reorg_undo.py
@@ -349,3 +349,41 @@ def test_schema_version_mismatch_raises():
     # not in __init__.
     with pytest.raises(RuntimeError, match='reindex'):
         idx.post_open_init()
+
+
+def test_live_contracts_reorg_roundtrip():
+    """A live_contracts decrement (contract destroyed) must be undone on reorg —
+    the whole token record is snapshotted, so backup restores the prior count."""
+    from electrumx.server.glyph_index import GlyphIndex, GlyphTokenInfo, pack_token_key
+    from electrumx.lib.glyph import GlyphProtocol, GlyphTokenType
+
+    db = FakeDB()
+    env = FakeEnv()
+    idx = GlyphIndex(db, env)
+    ref = b"\x33" * 36
+    key = pack_token_key(ref)
+
+    # Height 100: deploy with 3 live contracts
+    t = GlyphTokenInfo()
+    t.ref = ref
+    t.protocols = [GlyphProtocol.GLYPH_FT, GlyphProtocol.GLYPH_DMINT]
+    t.token_type = GlyphTokenType.DMINT
+    t.total_supply = 1000
+    t.mined_supply = 400
+    t.live_contracts = 3
+    idx.token_cache[ref] = t
+    idx.token_height[ref] = 100
+    idx.flush(FakeBatch(db.utxo_db._store))
+    assert GlyphTokenInfo.from_bytes(db.utxo_db.get(key)).live_contracts == 3
+
+    # Height 101: one contract destroyed → decrement to 2 and re-flush
+    t2 = GlyphTokenInfo.from_bytes(db.utxo_db.get(key))
+    t2.live_contracts -= 1
+    idx.token_cache[ref] = t2
+    idx.token_height[ref] = 101
+    idx.flush(FakeBatch(db.utxo_db._store))
+    assert GlyphTokenInfo.from_bytes(db.utxo_db.get(key)).live_contracts == 2
+
+    # Reorg unwinds height 101 → live_contracts restored to 3
+    idx.backup(FakeBatch(db.utxo_db._store), 101)
+    assert GlyphTokenInfo.from_bytes(db.utxo_db.get(key)).live_contracts == 3


### PR DESCRIPTION
## Summary
Implements **P1** of `docs/DMINT_BURN_DETECTION_SCOPE.md`: replaces the broken whole-token `is_spent` burn flag with **per-contract liveness** (`live_contracts`), so a multi-contract dMint is correctly classified as **mineable** (≥1 live contract + supply remaining), **fully mined**, or **burned** (all contracts gone with supply remaining).

Root cause it fixes: `_process_contract_burn` marked the *entire* token `is_spent` when *one* contract singleton was destroyed (terminal completion or OP_RETURN burn). For a multi-contract token that hid still-mineable tokens — e.g. **GRASS** (21 contracts, 75.9% mined) went dark when its first contract completed.

## Changes
**glyph_index.py**
- `GlyphTokenInfo.live_contracts` (CBOR `lc`); serialization preserves an explicit `0` (= no live contracts) vs `None` (= untracked, pre-v3). `is_fully_mined()` / `dmint_mineable()` centralize semantics (`None` ⇒ untracked → caller falls back to supply).
- Deploy registers **all** per-contract singletons via `_find_all_contract_refs`, filtered to the token ref's txid (`GEN:1..N`), excluding covenant/state singletons at other txids (validated on-chain). Sets `live_contracts = count`.
- `_process_contract_burn` **decrements** `live_contracts` instead of killing the token. Reorg-safe via the existing whole-record undo snapshot.
- Token dict exposes top-level `mineable` + `live_contracts`.
- **Schema → v3** (forces the backfill reindex).

**dmint_contracts.py**
- Sync gates `active` on the indexer's `mineable` signal, falling back to supply-only when untracked (no pre-v3 regression). Stores `live_contracts`; surfaces it as v2 `mineable_remaining` (was always `null`/`0`).

## Tests
Serialization roundtrip (incl. `0`/`None`), `dmint_mineable` semantics, `_find_all_contract_refs` filtering, manager `mineable`-gating (hide burned / list live / supply fallback), and a `live_contracts` **reorg** roundtrip. Full server suite green (421 passed, 11 skipped).

## ⚠️ Deploy = reindex required
Schema v3 hard-fails on the existing v2 DB by design. Rollout is **wipe electrumdb + full reindex (~10h)** — do **not** merge+rebuild prod outside a planned reindex window. The `mineable=None` fallback means burn detection activates only after the reindex backfills `live_contracts`; until then behaviour matches current supply-based logic.

## On-chain validation
Singleton-stability assumption confirmed: GRASS mint `6ad2ec9d…`@307645 both spent and recreated singleton `…f3:1`. See `docs/DMINT_BURN_DETECTION_SCOPE.md` §4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)