### PR TITLE
Raise Radiant REORG_LIMIT to 69 (match Radiant Core v3.1.2); pin radiantd v3.1.2

### DIFF
--- a/docker/full-stack/Dockerfile.radiantd
+++ b/docker/full-stack/Dockerfile.radiantd
@@ -5,8 +5,8 @@
 FROM ubuntu:22.04
 
 LABEL maintainer="radiantblockchain@protonmail.com"
-LABEL version="3.1.1"
-LABEL description="Radiant Node (radiantd) v3.1.1 built from Radiant-Core"
+LABEL version="3.1.2"
+LABEL description="Radiant Node (radiantd) v3.1.2 built from Radiant-Core"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -31,10 +31,10 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Clone Radiant-Core at the v3.1.1 release tag (pinned for reproducible builds).
+# Clone Radiant-Core at the v3.1.2 release tag (pinned for reproducible builds).
 # Pinning the tag also busts Docker's cached git-clone layer on a version bump,
 # so `docker compose build radiantd` can't silently rebuild the old source.
-RUN git clone --depth 1 --branch v3.1.1 https://github.com/Radiant-Core/Radiant-Core.git radiant
+RUN git clone --depth 1 --branch v3.1.2 https://github.com/Radiant-Core/Radiant-Core.git radiant
 
 WORKDIR /build/radiant
 

--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -215,6 +215,15 @@ class Radiant(Coin):
     GENESIS_ACTIVATION = 0
     RPC_PORT = 7332
     SESSIONCLS = RadiantElectrumX  # Use custom session with token support
+    # Must stay matched (>=) with Radiant Core's DEFAULT_MAX_REORG_DEPTH (69 as
+    # of node v3.1.2). The indexer retains block-undo data only for the last
+    # REORG_LIMIT blocks; if the node reorgs deeper than the indexer can undo,
+    # the indexer raises ChainError and needs a full resync. The base Coin
+    # default (6) matched the node's old finalization depth; both were raised to
+    # 69 after the 2026-06-15 deep-reorg partition so ordinary orphan races no
+    # longer strand nodes. NOTE: env.py lets a REORG_LIMIT env var override this
+    # default — clear any stale `REORG_LIMIT=6` in .env/compose so it doesn't win.
+    REORG_LIMIT = 69
 
 
 class RadiantTestnetMixin:

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -74,7 +74,7 @@ class Env(EnvBase):
         self.drop_client = self.custom("DROP_CLIENT", None, re.compile)
         self.cache_MB = self.integer('CACHE_MB', 1200)
 
-        # R26: use coin.REORG_LIMIT as default (Radiant coin sets 6 = node max reorg depth)
+        # R26: use coin.REORG_LIMIT as default (Radiant coin sets 69 = node max reorg depth)
         # Warn if set to an unreasonably low value
         self.reorg_limit = self.integer('REORG_LIMIT', self.coin.REORG_LIMIT)
         if self.reorg_limit < 2:


### PR DESCRIPTION
## Raise Radiant `REORG_LIMIT` to 69 to match Radiant Core v3.1.2

Coordinated with [Radiant-Core#3](https://github.com/Radiant-Core/Radiant-Core/pull/3), which raises the node's `DEFAULT_MAX_REORG_DEPTH` from 6 → **69** so ordinary orphan races no longer auto-finalize and partition the network (2026-06-15 incident).

**Why this must ship together:** the indexer keeps block-undo data only for the last `REORG_LIMIT` blocks. If the node can reorg up to 69 deep but the indexer only retains 6, a deep reorg raises `ChainError` and forces a **full resync**. The rule is **indexer ≥ node**.

### Changes
- `electrumx/lib/coins.py`: `class Radiant(Coin)` now sets `REORG_LIMIT = 69` (was inheriting base `6`). Testnet mixin (8000) unchanged.
- `docker/full-stack/Dockerfile.radiantd`: pin radiantd build to `v3.1.2`.
- `electrumx/server/env.py`: refresh stale "coin sets 6" comment.

### Operator action
`env.py` lets a `REORG_LIMIT` env var override this default — **clear any stale `REORG_LIMIT=6`** in `.env`/compose so the new default takes effect. A one-time >6-block reorg during the upgrade window may force a resync on any not-yet-bumped indexer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
