### PR TITLE
fix(glyph): WAVE companion rows, unclamped list limits, /wave/names pagination data loss

### DIFF
--- a/docs/GLYPH_API.md
+++ b/docs/GLYPH_API.md
@@ -229,6 +229,10 @@ Get tokens by type.
 | `cursor` | string | Opaque pagination cursor from previous `next_cursor` |
 | `order` | string | `ref` (default, legacy ref-hash order) or `recent` (newest-deployed first). Cursors are order-specific. |
 
+`order: "recent"` omits companion singletons (see
+[glyph.get_recent](#glyphget_recent)); `order: "ref"` does not, so the legacy
+listing stays a complete enumeration of the type.
+
 **Returns:** `{tokens, next_cursor}`
 
 > **List responses omit raw embed payloads** (since `3131999`, 2026-07-19). All paginated
@@ -252,6 +256,16 @@ that never resolved a type (`UNKNOWN`/0 — empty or malformed reveals, and
 partial WAVE-name owner rows) are excluded here; query them explicitly with
 `token_type: 0`.
 
+> **`token_type: 0` is the only way to list UNKNOWN records.** They carry no
+> other primary type, so they appear in no other recency feed. This is
+> intended — but it also means an *absent* type filter and `token_type: 0` are
+> very different queries, not "all" and "all, redundantly". If your client
+> builds the filter by parsing a possibly-empty string, make sure the empty
+> case yields *no* filter rather than `[0]`; the `0` bucket is small and
+> advances only when a malformed reveal lands, so a client that accidentally
+> pins it sees a sparse, stale-looking feed of nameless type-0 rows and can
+> easily mistake that for a broken index.
+
 **Parameters:**
 | Name | Type | Description |
 |------|------|-------------|
@@ -260,6 +274,49 @@ partial WAVE-name owner rows) are excluded here; query them explicitly with
 | `token_type` | int | Optional GlyphTokenType filter; omit for all *typed* tokens. Pass `0` for the UNKNOWN bucket. |
 
 **Returns:** `{tokens, next_cursor}`
+
+#### Companion singletons are excluded from the recency feeds
+
+A single mint often creates more than one glyph output. A WAVE name
+registration mints the **name singleton at vout 0** (type 5, named, protocols
+`[2, 5, 11]`) *and* its **zone/mutable contract at vout 1**, which is a real
+on-chain token in its own right but is indexed with no name and no metadata
+(type 2, `name: null`, protocols `[2]`). A dMint deploy does the same thing
+with one mining-contract singleton per parallel contract at vout 1..N.
+
+These companion outputs are the parent token's plumbing, not separately
+discoverable assets. Before they were excluded, every WAVE registration put a
+nameless twin in the feed — on mainnet that was **47% of an all-types page**
+(28 nameless companions against 28 registrations in 60 rows). They are now
+omitted from both `glyph.get_recent` (all-types and per-type) and
+`glyph.get_tokens_by_type` with `order: "recent"`.
+
+They are **not** hidden generally. A companion is still returned by:
+
+- `glyph.get_by_ref` / `glyph.get_metadata` — direct lookup by ref
+- `glyph.get_tokens_by_type` with the default `order: "ref"`, which remains a
+  complete enumeration of the type
+- the by-protocol facet lists
+
+Every token row carries two fields for this:
+
+| Field | Meaning |
+|-------|---------|
+| `is_companion` | `true` if this row is a sibling singleton owned by another token minted in the same tx |
+| `parent_ref` | canonical `txid_vout` of the owning token (the WAVE name / dMint token), directly comparable to another row's `ref` |
+
+Clients that previously paired a nameless type-2 row against a type-5 row
+sharing its txid should drop that heuristic: it cannot work across a page
+boundary, where only one half of the pair is visible. Filter on
+`is_companion` instead, or simply rely on the feeds, which no longer contain
+them.
+
+> **Backends indexed before this change** still hold the companion rows in
+> their discovery index. The read path re-derives the property for records that
+> predate the `is_companion` field, so those backends serve clean feeds
+> immediately without a reindex — but on such a backend `is_companion` itself
+> reads `false` on the older rows. Treat the *feeds* as authoritative and the
+> field as a bonus until the backend has reindexed.
 
 ---
 

--- a/docs/GLYPH_API.md
+++ b/docs/GLYPH_API.md
@@ -225,7 +225,7 @@ Get tokens by type.
 | Name | Type | Description |
 |------|------|-------------|
 | `token_type` | int | GlyphTokenType ID (1=FT, 2=NFT, etc.) |
-| `limit` | int | Maximum results (default 100) |
+| `limit` | int | Maximum results (default 100, **clamped to 500**) |
 | `cursor` | string | Opaque pagination cursor from previous `next_cursor` |
 | `order` | string | `ref` (default, legacy ref-hash order) or `recent` (newest-deployed first). Cursors are order-specific. |
 
@@ -269,7 +269,7 @@ partial WAVE-name owner rows) are excluded here; query them explicitly with
 **Parameters:**
 | Name | Type | Description |
 |------|------|-------------|
-| `limit` | int | Maximum results (default 100) |
+| `limit` | int | Maximum results (default 100, **clamped to 500**) |
 | `cursor` | string | Opaque pagination cursor from previous `next_cursor` |
 | `token_type` | int | Optional GlyphTokenType filter; omit for all *typed* tokens. Pass `0` for the UNKNOWN bucket. |
 

--- a/electrumx/server/glyph_api.py
+++ b/electrumx/server/glyph_api.py
@@ -38,6 +38,27 @@ from electrumx.server.glyph_subscriptions import SubscriptionLimitError
 # See docs/pagination-cursors.md.
 _CURSOR_UNSET = object()
 
+# Upper bound for hydrated list pages. Matches the REST side, where FastAPI
+# already enforces it via Query(le=500).
+_MAX_LIST_LIMIT = 500
+
+
+def _clamp_list_limit(limit: int, maximum: int = _MAX_LIST_LIMIT) -> int:
+    """Clamp a client-supplied page size for a hydrated list endpoint.
+
+    Every row a list endpoint scans costs a ``get_token`` DB read, and rows
+    dropped by a hydration predicate are read without counting toward the page
+    — so an unbounded ``limit`` lets one cheap (cost 2.0) call walk an entire
+    index. The floor of 1 matters too: ``_paginate_hydrated`` breaks on
+    ``len(results) >= limit``, so ``limit <= 0`` would return an empty page
+    *with* a cursor, which a paginating client follows forever.
+    """
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return maximum
+    return max(1, min(limit, maximum))
+
 
 class GlyphAPIMixin:
     """
@@ -514,7 +535,9 @@ class GlyphAPIMixin:
 
         Args:
             token_type: GlyphTokenType ID (1=FT, 2=NFT, 3=DAT, 4=DMINT, etc.)
-            limit: Maximum results
+            limit: Maximum results (clamped to 1..500 — each row costs a
+                   get_token DB read, and filtered rows are hydrated without
+                   counting toward the page)
             cursor: Opaque pagination cursor from previous response next_cursor
             order: 'ref' (default, legacy ref-hash order) or 'recent'
                    (newest-deployed first, via the v4 recency index). Cursors
@@ -529,7 +552,7 @@ class GlyphAPIMixin:
             return {'error': 'Glyph indexing not enabled'}
 
         return self.glyph_index.get_tokens_by_type(
-            token_type, limit=limit, cursor=cursor, order=order
+            token_type, limit=_clamp_list_limit(limit), cursor=cursor, order=order
         )
 
     async def glyph_get_recent(self, limit: int = 100, cursor: str = None,
@@ -538,7 +561,8 @@ class GlyphAPIMixin:
         Newest-deployed Glyph tokens (v4 discovery index).
 
         Args:
-            limit: Maximum results
+            limit: Maximum results (clamped to 1..500 — see
+                   glyph_get_tokens_by_type)
             cursor: Opaque pagination cursor from previous response next_cursor
             token_type: Optional GlyphTokenType filter. When given, lists newest
                         tokens of that type; otherwise newest across all types.
@@ -551,6 +575,7 @@ class GlyphAPIMixin:
         if not hasattr(self, 'glyph_index') or not self.glyph_index:
             return {'error': 'Glyph indexing not enabled'}
 
+        limit = _clamp_list_limit(limit)
         if token_type is not None:
             return self.glyph_index.get_tokens_by_type(
                 token_type, limit=limit, cursor=cursor, order='recent'

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -2306,6 +2306,25 @@ class GlyphIndex:
         """
         return base64.urlsafe_b64encode(raw_key).decode()
 
+    def cursor_for_type_ref(self, token_type: int, ref: bytes) -> str:
+        """Cursor that resumes a ``get_tokens_by_type(order='ref')`` walk *at*
+        ``ref`` — i.e. ``ref`` is the first token the next page returns.
+
+        For callers that post-filter a page and stop partway through it. The
+        cursor ``get_tokens_by_type`` hands back points past everything it
+        scanned, so a caller that consumed only a prefix of the page and then
+        reused that cursor would silently skip the remainder. Building the
+        resume point from the first *unconsumed* token instead keeps the walk
+        gap-free. Seeks are inclusive, so the named ref is returned, not
+        skipped.
+
+        Only valid for the default ``order='ref'`` index (BY_TYPE); the recency
+        index keys embed deploy_height, so its cursors are not reconstructible
+        from a ref alone.
+        """
+        return self._encode_cursor(
+            GlyphDBKeys.BY_TYPE + struct.pack('<B', token_type & 0xFF) + ref)
+
     def get_balances_for_scripthash(self, scripthash: bytes,
                                      limit: int = 100,
                                      cursor: Optional[str] = None) -> Dict[str, Any]:

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -258,6 +258,8 @@ class GlyphTokenInfo:
         'is_timelocked', 'timelock_mode', 'timelock_unlock_at', 'timelock_cek_hash', 'timelock_hint',
         # WAVE naming (REP-3011)
         'is_wave_duplicate',  # True if this WAVE name token is a duplicate (not canonical)
+        # Companion/plumbing singleton (see _mark_companion_singletons)
+        'is_companion',  # True if this is a sibling singleton owned by another token
     )
     
     def __init__(self):
@@ -321,6 +323,10 @@ class GlyphTokenInfo:
         self.timelock_hint = None       # Optional viewer hint
         # WAVE naming (REP-3011)
         self.is_wave_duplicate = False  # True if this WAVE name is a duplicate (not canonical)
+        # Companion/plumbing singleton owned by another token in the same tx
+        # (WAVE zone contract, dMint mining contract). See
+        # _mark_companion_singletons; parent_ref points at the owning token.
+        self.is_companion = False
     
     def to_bytes(self) -> bytes:
         """Serialize token info to CBOR bytes for flexible storage."""
@@ -382,6 +388,8 @@ class GlyphTokenInfo:
             'th': self.timelock_hint,
             # WAVE naming
             'wd': self.is_wave_duplicate or None,
+            # Companion singleton
+            'cn': self.is_companion or None,
         }
         # Remove None values to save space
         data = {k: v for k, v in data.items() if v is not None and v != 0 and v != b''}
@@ -456,7 +464,11 @@ class GlyphTokenInfo:
         info.timelock_hint = d.get('th')
         # WAVE naming
         info.is_wave_duplicate = bool(d.get('wd', False))
-        
+        # Companion singleton (absent on records written before this field
+        # existed — the read-side filter derives it for those, see
+        # _is_companion_singleton).
+        info.is_companion = bool(d.get('cn', False))
+
         return info
     
     def percent_mined(self) -> float:
@@ -1093,6 +1105,16 @@ class GlyphIndex:
 
         Returns a set of 36-byte contract refs (may be empty).
         """
+        return self._find_sibling_singletons(tx, token_ref)
+
+    def _find_sibling_singletons(self, tx: 'Tx', token_ref: bytes) -> set:
+        """Singleton refs minted by the same tx as ``token_ref``, excluding it.
+
+        The shared primitive behind ``_find_all_contract_refs`` (dMint mining
+        contracts) and ``_mark_companion_singletons`` (WAVE zone contracts):
+        both are "extra singleton outputs a mint created alongside the token
+        itself", and both use the same on-chain-verified filter.
+        """
         token_txid = token_ref[:32]
         found = set()
         for output in tx.outputs:
@@ -1102,6 +1124,63 @@ class GlyphIndex:
                         and ref_bytes[:32] == token_txid):
                     found.add(ref_bytes)
         return found
+
+    def _mark_companion_singletons(self, ref: bytes, tx: 'Tx',
+                                   height: int) -> int:
+        """Flag the sibling singletons a revealed token minted alongside itself.
+
+        A Glyph mint routinely creates more than one singleton output in one tx.
+        A WAVE registration mints the name singleton at vout 0 and its
+        zone/mutable contract at vout 1; a dMint deploy mints the token at
+        vout 0 and one contract singleton per parallel miner at vout 1..N.
+        Phase 1 registers *every* previously-unseen ref it finds in the outputs
+        as a token, but only the ref ``_find_output_ref`` returns (the first
+        singleton, i.e. vout 0) is later enriched by the reveal — so the
+        siblings persist as bare ``NFT`` / protocols ``[2]`` records with
+        ``name=None`` and no metadata.
+
+        Those records are honest: the outputs really are distinct on-chain
+        singletons, and they stay fully queryable by ref, by BY_TYPE and by
+        BY_PROTO. But they are the parent's plumbing rather than separately
+        discoverable assets, and on mainnet they are not a rare edge case —
+        every WAVE registration contributes one, so they were ~47% of the
+        all-types recency feed. Marking them here keeps them out of the
+        recency feeds (see ``_discovery_rows``) and gives clients an explicit
+        ``is_companion`` flag plus a ``parent_ref`` back-link, so nobody has to
+        reconstruct the pairing with a txid heuristic that breaks across page
+        boundaries.
+
+        The flag lives on the token record rather than being recomputed at
+        index-write time on purpose: ``_discovery_rows`` must stay a pure
+        function of ``(ref, token)`` so the live write path, the re-write
+        dedup, ``_delete_discovery_rows`` and the migration all derive the
+        exact same key set.
+
+        Returns the number of newly-marked siblings.
+        """
+        marked = 0
+        for sib_ref in self._find_sibling_singletons(tx, ref):
+            sib = self.token_cache.get(sib_ref)
+            if sib is None:
+                # Reveal landed in a later block than the mint: pull the record
+                # back into the cache so this flush rewrites it (the re-write
+                # path in flush() drops its stale discovery rows first).
+                sib = self.get_token(sib_ref)
+                if sib is None:
+                    continue
+                self.token_cache[sib_ref] = sib
+            if sib.is_companion:
+                continue
+            # Only ever demote a bare Phase-1 record. A sibling that carries its
+            # own name or metadata was revealed in its own right and is a real
+            # asset, not plumbing.
+            if sib.name or sib.metadata_hash:
+                continue
+            sib.is_companion = True
+            sib.parent_ref = ref_to_display(ref)  # canonical txid_vout
+            self.token_height[sib_ref] = height
+            marked += 1
+        return marked
 
     def _parse_deploy_contract_state(self, token: 'GlyphTokenInfo', tx: 'Tx'):
         """
@@ -1500,6 +1579,17 @@ class GlyphIndex:
         self.token_cache[ref] = token
         self.token_height[ref] = height
 
+        # Demote any sibling singletons this mint created (WAVE zone contract,
+        # dMint mining contracts) so they stay out of the recency feeds. Runs
+        # after the token is cached so a self-referential tx can't mark the
+        # revealed token itself.
+        companions = self._mark_companion_singletons(ref, tx, height)
+        if companions:
+            self.logger.info(
+                f'Glyph companion singletons: {companions} sibling output(s) of '
+                f'{ref_to_display(ref)} marked as plumbing (excluded from '
+                f'recency feeds)')
+
         # Add deploy event to history
         history_key = pack_history_key(ref, height, tx_idx)
         history_value = struct.pack('<B', GlyphEventType.DEPLOY) + tx_hash
@@ -1772,21 +1862,60 @@ class GlyphIndex:
         together and can be recreated/deleted deterministically from a token
         record.
 
-        GLOBAL_RECENT deliberately omits ``UNKNOWN`` (type 0) records so the
-        global ``glyph.get_recent`` feed matches the union of the per-type
-        recency lists. Type 0 is the catch-all for records that never resolved a
-        primary type — empty/malformed reveals (no protocols, no name) and
-        partial WAVE-name owner rows (protocol 11 without NFT, cf. wave_index
-        "track name owner on plain transfers"). Those still get a
-        BY_TYPE_RECENT row under type 0 (reachable via
-        ``get_recent(token_type=0)``) and their BY_PROTO facet rows, so nothing
-        is dropped — they are just kept out of the curated global feed, where
-        they surfaced as half-hydrated noise (v4 launch-day report). ``get_token``
-        hydration is symmetric across both feeds; this is the one point where the
-        global feed and the per-type indexes are intentionally allowed to differ.
+        Two kinds of record are curated out of the recency feeds. Both remain
+        fully queryable by ref (``get_token``), by BY_TYPE and by BY_PROTO —
+        the exclusions are about feed density, not about hiding data.
+
+        1. ``UNKNOWN`` (type 0) is omitted from GLOBAL_RECENT, so the global
+           feed matches the union of the per-type recency lists. Type 0 is the
+           catch-all for records that never resolved a primary type —
+           empty/malformed reveals (no protocols, no name) and partial
+           WAVE-name owner rows (protocol 11 without NFT, cf. wave_index
+           "track name owner on plain transfers"). They keep their
+           BY_TYPE_RECENT row under type 0, reachable via
+           ``get_recent(token_type=0)``, which is the *only* way to list them.
+
+           Provenance note: this exclusion was introduced in 423e020 citing a
+           launch-day report of a polluted global feed. That report was later
+           retracted — the reporting client was passing ``token_type=0``
+           through a parameter-parsing bug, so it was querying the UNKNOWN
+           bucket directly and seeing its honest contents; the real all-types
+           feed measured clean both before and after the fix. The exclusion is
+           kept on its own merits (the write path genuinely did index type-0
+           records here, so the feed *could* surface them), not on that
+           evidence. The same commit's "per-backend skew from load-balanced
+           backends" aside described a staleness symptom that never happened;
+           there is one backend. Do not go hunting it.
+
+        2. Companion singletons (``token.is_companion``) are omitted from both
+           GLOBAL_RECENT *and* BY_TYPE_RECENT. These are the extra singleton
+           outputs a mint creates alongside the token itself — a WAVE
+           registration's zone/mutable contract at vout 1, a dMint deploy's
+           mining contracts at vout 1..N — which Phase 1 registers as bare
+           ``NFT``/``[2]`` records with no name and no metadata. See
+           ``_mark_companion_singletons``. On mainnet every WAVE registration
+           contributed one, so before this exclusion they were ~47% of the
+           all-types feed and a comparable share of the type-2 feed; unlike the
+           type-0 case there is no separate bucket they would land in, so they
+           are dropped from the recency indexes outright and located instead
+           via the ``parent_ref`` back-link on the record.
+
+        ``get_token`` hydration is symmetric across all feeds; this generator is
+        the one point where the global feed and the per-type indexes are
+        intentionally allowed to differ.
+
+        Must stay a pure function of ``(ref, token)``: the live write path, the
+        re-write dedup in ``flush()``, ``_delete_discovery_rows`` and
+        ``_migrate_3_to_4`` all call it and must derive an identical key set, or
+        rows orphan.
         """
         dh = token.deploy_height
         tt = token.token_type
+        if token.is_companion:
+            # No recency rows at all — only the protocol facets.
+            for proto in set(token.protocols or ()):
+                yield pack_proto_key(proto, dh, ref), b''
+            return
         yield pack_type_recent_key(tt, dh, ref), b''
         if tt != GlyphTokenType.UNKNOWN:
             yield pack_global_recent_key(dh, ref), struct.pack('<B', tt & 0xFF)
@@ -2448,6 +2577,44 @@ class GlyphIndex:
                 results.append(self._token_to_dict(token, include_embed_data=False))
         return {'tokens': results, 'next_cursor': next_cursor}
 
+    def _is_companion_singleton(self, token: 'GlyphTokenInfo') -> bool:
+        """Whether a hydrated record is a companion/plumbing singleton.
+
+        Prefers the stored ``is_companion`` flag. Records written before that
+        flag existed do not carry it, so for those the property is re-derived
+        here — which lets a DB indexed by an earlier build serve clean recency
+        feeds immediately, with no reindex (same approach 423e020 took for its
+        UNKNOWN read predicate).
+
+        The derivation mirrors ``_mark_companion_singletons``: a companion is a
+        bare Phase-1 singleton (no name, no metadata, plain ``NFT``/``[2]``) at
+        a non-zero vout whose vout-0 sibling in the same tx is a named token.
+        The structural checks run first and are pure record reads, so the extra
+        ``get_token`` only happens for rows that already look like plumbing.
+
+        Known trade-off: a batch mint that put several *genuinely distinct*
+        bare NFTs in one tx behind a named vout-0 token would also be filtered.
+        Such records are indistinguishable from plumbing at the record level —
+        this indexer only enriches one ref per reveal, so the others carry no
+        name or metadata either — and they are equally uninformative in a feed.
+        They stay reachable by ref, by BY_TYPE and by BY_PROTO.
+        """
+        if token.is_companion:
+            return True
+        if token.name or token.metadata_hash or token.parent_ref:
+            return False
+        if token.token_type != GlyphTokenType.NFT:
+            return False
+        if list(token.protocols or ()) != [GlyphProtocol.GLYPH_NFT]:
+            return False
+        if len(token.ref or b'') != 36:
+            return False  # malformed record — never raise from a list page
+        txid, vout = unpack_ref(token.ref)
+        if vout == 0:
+            return False  # vout 0 is the owning token, never the plumbing
+        parent = self.get_token(pack_ref(txid, 0))
+        return bool(parent is not None and parent.name)
+
     def get_tokens_by_type(self, token_type: int, limit: int = 100,
                            cursor: Optional[str] = None,
                            order: str = 'ref') -> Dict[str, Any]:
@@ -2458,27 +2625,37 @@ class GlyphIndex:
         cursors keep working. ``order='recent'`` — newest-deployed first via the
         v4 BY_TYPE_RECENT index. Cursors are order-specific (opaque raw keys) and
         must not be carried across a change of ``order``.
+
+        ``order='recent'`` additionally hides companion singletons (see
+        ``_discovery_rows``); ``order='ref'`` does not, so the legacy listing
+        stays a complete enumeration of the type.
         """
         if order == 'recent':
             prefix = GlyphDBKeys.BY_TYPE_RECENT + struct.pack('<B', token_type & 0xFF)
+            predicate = lambda t: not self._is_companion_singleton(t)  # noqa: E731
         else:
             prefix = GlyphDBKeys.BY_TYPE + struct.pack('<B', token_type & 0xFF)
-        return self._paginate_hydrated(prefix, limit, cursor)
+            predicate = None
+        return self._paginate_hydrated(prefix, limit, cursor, predicate=predicate)
 
     def get_recent_tokens(self, limit: int = 100,
                           cursor: Optional[str] = None) -> Dict[str, Any]:
         """Newest-deployed *typed* tokens across every type (v4 GLOBAL_RECENT).
 
         Matches the union of the per-type recency lists. The write path no
-        longer indexes UNKNOWN (type 0) records here, but a DB backfilled by an
-        earlier v4 build still holds those rows; the ``token_type != UNKNOWN``
-        predicate skips them on read so every backend serves a clean feed
+        longer indexes UNKNOWN (type 0) records or companion singletons here,
+        but a DB backfilled by an earlier build still holds those rows; the
+        read predicate skips both so every backend serves a clean feed
         immediately, without a re-migration. The cursor still advances over
         skipped rows (see ``_paginate_hydrated``), so pagination is unaffected.
+
+        See ``_discovery_rows`` for what each exclusion covers and why.
         """
         return self._paginate_hydrated(
             GlyphDBKeys.GLOBAL_RECENT, limit, cursor,
-            predicate=lambda token: token.token_type != GlyphTokenType.UNKNOWN)
+            predicate=lambda token: (
+                token.token_type != GlyphTokenType.UNKNOWN
+                and not self._is_companion_singleton(token)))
 
     def get_tokens_by_protocol(self, proto: int, limit: int = 100,
                                cursor: Optional[str] = None) -> Dict[str, Any]:
@@ -2559,6 +2736,11 @@ class GlyphIndex:
             'container_ref': token.container_ref,
             'authority_ref': token.authority_ref,
             'parent_ref': token.parent_ref,
+            # True for a sibling singleton owned by another token minted in the
+            # same tx (WAVE zone contract, dMint mining contract). Such rows are
+            # hidden from the recency feeds but still returned by direct and
+            # by-type lookups, so clients can drop them without txid pairing.
+            'is_companion': token.is_companion,
         }
         
         # Include image/content info

--- a/electrumx/server/rest_api.py
+++ b/electrumx/server/rest_api.py
@@ -1841,84 +1841,128 @@ async def wave_stats():
         raise _internal_error(e)
 
 
+# /wave/names post-filters the type-5 token list (duplicate registrations are
+# dropped), so it must scan more rows than it emits. These bound that scan:
+# rows are hydrated one get_token at a time, so an unbounded over-fetch turns
+# one request into tens of thousands of DB reads.
+_WAVE_NAMES_SCAN_CHUNK = 500   # rows fetched per underlying index page
+_WAVE_NAMES_MAX_SCAN = 5000    # hard ceiling on rows examined per request
+
+
+def _wave_name_entry(token: dict, include_duplicates: bool) -> Optional[dict]:
+    """Build a /wave/names entry, or None if this token is not a canonical
+    registration (duplicate, or absent from the wave index)."""
+    attrs = token.get('attrs') or {}
+    name = attrs.get('name', '')
+    if not name:
+        return None
+
+    # Is this token the canonical (first) registration? The wave index stores
+    # claim_ref = tx_hash+vout(0) for canonical entries, and the glyph token's
+    # deploy_txid is the same tx. canonical_ref[:32] is the tx_hash in
+    # little-endian; deploy_txid is hex in reversed (display) order.
+    canonical_ref = _wave_index._resolve_name_to_ref(name)
+    if canonical_ref is None:
+        return None
+    if canonical_ref[:32][::-1].hex() != token.get('deploy_txid', ''):
+        return None  # duplicate registration
+
+    domain = attrs.get('domain', 'rxd')
+    entry = {
+        'name': name,
+        'domain': domain,
+        'full_name': f"{name}.{domain}",
+        'target': attrs.get('target', ''),
+        'ref': token.get('ref', ''),
+        'height': token.get('deploy_height', 0),
+        'spent': token.get('is_spent', False),
+        'canonical': True,
+    }
+    if include_duplicates:
+        entry['has_duplicates'] = _wave_index._has_duplicates(name)
+    return entry
+
+
 @app.get("/wave/names", tags=["WAVE"])
 async def wave_list_names(
-    limit: int = Query(default=500, le=2000),
+    limit: int = Query(default=500, ge=1, le=2000),
     cursor: Optional[str] = Query(default=None, description="Pagination cursor"),
     include_duplicates: bool = Query(default=False, description="Include duplicate count for each name"),
 ):
     """List all registered WAVE names with their targets.
-    
+
     Returns a compact list sourced from the Glyph token index (type 5 = WAVE).
     Supports cursor-based pagination for large result sets.
-    
+
     Note: The canonical (first) registration is always returned for each name.
     Later registrations of the same name are tracked as duplicates but not used for resolution.
+
+    A page can be short without meaning the walk is over: duplicates are
+    filtered out after the index scan, and the scan is capped per request. Keep
+    following `next_cursor` until it comes back `null` — that, not a short
+    page, is the end of the list.
     """
     _ensure_wave()
     if not _glyph_index:
         raise HTTPException(status_code=503, detail="Glyph index not available")
 
     try:
-        # Decode cursor for glyph BY_TYPE pagination
-        result = _glyph_index.get_tokens_by_type(5, limit=limit * 3, cursor=cursor)
-        tokens = result.get('tokens', [])
+        from electrumx.lib.glyph import GlyphTokenType
 
-        # Deduplicate: for each name, keep only the canonical (first-registration) token.
-        # The wave index stores the canonical ref per name; any token whose glyph ref
-        # does NOT match the wave canonical ref is a duplicate.
+        names: list = []
         seen_names: set = set()
-        names = []
-        for token in tokens:
-            attrs = token.get('attrs') or {}
-            name = attrs.get('name', '')
-            domain = attrs.get('domain', 'rxd')
-            if not name:
-                continue
+        next_cursor = None
+        scan_cursor = cursor
+        scanned = 0
+        exhausted = False
 
-            full_name = f"{name}.{domain}"
-            token_ref_str = token.get('ref', '')
+        # Walk the type-5 index in bounded chunks until the page is full, the
+        # index runs out, or we hit the scan ceiling.
+        while len(names) < limit and scanned < _WAVE_NAMES_MAX_SCAN:
+            page = _glyph_index.get_tokens_by_type(
+                GlyphTokenType.WAVE,
+                limit=min(_WAVE_NAMES_SCAN_CHUNK, _WAVE_NAMES_MAX_SCAN - scanned),
+                cursor=scan_cursor,
+            )
+            tokens = page.get('tokens', [])
+            if not tokens:
+                exhausted = True
+                break
 
-            # Skip if we've already emitted this name
-            if full_name in seen_names:
-                continue
+            resume_at = None  # index of the first token this page did NOT consume
+            for i, token in enumerate(tokens):
+                scanned += 1
+                entry = _wave_name_entry(token, include_duplicates)
+                if entry is None or entry['full_name'] in seen_names:
+                    continue
+                seen_names.add(entry['full_name'])
+                names.append(entry)
+                if len(names) >= limit:
+                    resume_at = i + 1
+                    break
 
-            # Check wave index: is this token the canonical (first) registration?
-            # The wave index stores claim_ref = tx_hash+vout(0) for canonical entries.
-            # The glyph token's deploy_txid equals the claim_ref txid (same tx).
-            canonical_ref = _wave_index._resolve_name_to_ref(name)
-            if canonical_ref is None:
-                # Not in wave index — skip
-                continue
+            if resume_at is not None and resume_at < len(tokens):
+                # Stopped mid-page: resume at the first token we did not consume.
+                # The page's own next_cursor points past the whole chunk and
+                # would drop everything after the break.
+                next_cursor = _glyph_index.cursor_for_type_ref(
+                    GlyphTokenType.WAVE,
+                    bytes.fromhex(tokens[resume_at]['ref_hex']))
+                break
 
-            # canonical_ref[:32] is the tx_hash (little-endian), deploy_txid is hex (reversed)
-            canonical_txid_hex = canonical_ref[:32][::-1].hex()
-            token_deploy_txid = token.get('deploy_txid', '')
-            if canonical_txid_hex != token_deploy_txid:
-                # This is a duplicate registration — skip
-                continue
-
-            seen_names.add(full_name)
-            name_entry = {
-                'name': name,
-                'domain': domain,
-                'full_name': full_name,
-                'target': attrs.get('target', ''),
-                'ref': token_ref_str,
-                'height': token.get('deploy_height', 0),
-                'spent': token.get('is_spent', False),
-                'canonical': True,
-            }
-            if include_duplicates:
-                name_entry['has_duplicates'] = _wave_index._has_duplicates(name)
-            names.append(name_entry)
-            if len(names) >= limit:
+            # Consumed the chunk to its end — carry the index's own cursor.
+            scan_cursor = page.get('next_cursor')
+            next_cursor = scan_cursor
+            if scan_cursor is None:
+                exhausted = True
                 break
 
         return {
             'names': names,
             'total': len(names),
-            'next_cursor': result.get('next_cursor') if len(names) >= limit else None,
+            # None only when the underlying index is genuinely exhausted; a
+            # short page from the scan ceiling still returns a cursor.
+            'next_cursor': None if exhausted else next_cursor,
         }
     except Exception as e:
         raise _internal_error(e)

--- a/tests/server/test_discovery_index.py
+++ b/tests/server/test_discovery_index.py
@@ -8,6 +8,7 @@ Covers:
 - get_tokens_by_protocol (facets that are not a primary token_type)
 - Reorg: backup() removes the v4 rows written at a height (add/spend symmetry)
 - In-place v3 -> v4 backfill migration + schema-version gating
+- Curation of the recency feeds: UNKNOWN (type 0) and companion singletons
 """
 
 import contextlib
@@ -209,9 +210,16 @@ class TestGlobalRecentAndProto:
 
 # --------------------------------------------------------------------------- #
 # GLOBAL_RECENT excludes UNKNOWN (type 0) so it matches the per-type feeds.
-# (v4 launch-day report: the global feed was polluted with half-hydrated type-0
-# rows — empty/malformed reveals and partial WAVE-name owner rows — that the
-# per-type recency queries never surface.)
+#
+# Kept as a write-path invariant, NOT because of the launch-day report that
+# originally motivated it (423e020): that report was retracted — the reporting
+# client had a parameter-parsing bug and was querying token_type=0, i.e. the
+# UNKNOWN bucket itself, so the type-0 rows and apparent staleness it saw were
+# that bucket's honest contents. The real all-types feed measured clean before
+# and after. What survives is the code fact these tests pin: _discovery_rows
+# did unconditionally index type-0 records into GLOBAL_RECENT, so the feed
+# could surface half-hydrated rows (no name, no protocols) even though it
+# happened not to at the time.
 # --------------------------------------------------------------------------- #
 
 class TestGlobalRecentExcludesUnknown:
@@ -415,3 +423,281 @@ class TestMigration:
         db.utxo_db._store[GlyphDBKeys.SCHEMA_VERSION] = bytes([CURRENT_SCHEMA_VERSION + 1])
         with pytest.raises(RuntimeError):
             idx._check_schema_version()
+
+
+# --------------------------------------------------------------------------- #
+# Companion singletons: a mint's extra singleton outputs (WAVE zone/mutable
+# contract at vout 1, dMint mining contracts at vout 1..N) are Phase-1
+# registered as bare NFT/[2] records with no name. They are the parent's
+# plumbing, not separately discoverable assets, so they are kept out of BOTH
+# recency feeds. Verified on mainnet: every WAVE registration contributed one,
+# ~47% of the all-types feed.
+# --------------------------------------------------------------------------- #
+
+class _FakeOutput:
+    def __init__(self, script):
+        self.pk_script = script
+
+
+class _FakeTx:
+    """Minimal tx whose outputs carry OP_PUSHINPUTREFSINGLETON (0xd8) pushes."""
+    def __init__(self, *refs):
+        self.outputs = [_FakeOutput(b"\xd8" + r) for r in refs]
+
+
+def _token_at(name, txid_hex, vout, height, token_type, protocols,
+              revealed=True):
+    """Like _token but at an explicit vout, and optionally 'bare' (no metadata),
+    which is how Phase 1 leaves a singleton the reveal never enriched."""
+    t = GlyphTokenInfo()
+    t.ref = pack_ref(bytes.fromhex(txid_hex), vout)
+    t.name = name
+    t.token_type = token_type
+    t.protocols = list(protocols)
+    t.deploy_height = height
+    t.deploy_txid = bytes.fromhex(txid_hex)
+    t.metadata_hash = bytes(32) if revealed else b""
+    return t
+
+
+WAVE_TXID = "76a32cb6" * 8
+
+
+def _wave_registration(height=447893):
+    """The real on-chain shape: name singleton at vout 0, zone contract at
+    vout 1 (mainnet example 76a32cb6_0 = '440000.rxd' / 76a32cb6_1 = nameless)."""
+    name = _token_at("440000.rxd", WAVE_TXID, 0, height, GlyphTokenType.WAVE,
+                     [GlyphProtocol.GLYPH_NFT, GlyphProtocol.GLYPH_MUT,
+                      GlyphProtocol.GLYPH_WAVE])
+    zone = _token_at(None, WAVE_TXID, 1, height, GlyphTokenType.NFT,
+                     [GlyphProtocol.GLYPH_NFT], revealed=False)
+    return name, zone
+
+
+class TestCompanionSingletonMarking:
+    def test_reveal_marks_sibling_singleton(self):
+        idx, _db = _make_index()
+        name, zone = _wave_registration()
+        for t in (name, zone):
+            idx.token_cache[t.ref] = t
+            idx.token_height[t.ref] = t.deploy_height
+
+        marked = idx._mark_companion_singletons(
+            name.ref, _FakeTx(name.ref, zone.ref), name.deploy_height)
+
+        assert marked == 1
+        assert zone.is_companion is True
+        # Back-link is the canonical txid_vout display form, directly
+        # comparable to the 'ref' field of the parent's API row.
+        assert zone.parent_ref == idx._token_to_dict(name)["ref"]
+        assert name.is_companion is False  # never demotes itself
+
+    def test_named_sibling_is_not_demoted(self):
+        """A sibling that was revealed in its own right is a real asset."""
+        idx, _db = _make_index()
+        name, _zone = _wave_registration()
+        sibling = _token_at("REAL", WAVE_TXID, 1, 447893, GlyphTokenType.NFT,
+                            [GlyphProtocol.GLYPH_NFT])
+        for t in (name, sibling):
+            idx.token_cache[t.ref] = t
+            idx.token_height[t.ref] = t.deploy_height
+
+        assert idx._mark_companion_singletons(
+            name.ref, _FakeTx(name.ref, sibling.ref), 447893) == 0
+        assert sibling.is_companion is False
+
+    def test_marking_is_idempotent(self):
+        idx, _db = _make_index()
+        name, zone = _wave_registration()
+        for t in (name, zone):
+            idx.token_cache[t.ref] = t
+            idx.token_height[t.ref] = t.deploy_height
+        tx = _FakeTx(name.ref, zone.ref)
+
+        assert idx._mark_companion_singletons(name.ref, tx, 447893) == 1
+        assert idx._mark_companion_singletons(name.ref, tx, 447893) == 0
+
+
+class TestCompanionExcludedFromRecencyFeeds:
+    def _seed(self, mark=True):
+        idx, db = _make_index()
+        name, zone = _wave_registration()
+        other = _token_at("PLAIN", "aa" * 32, 0, 447800, GlyphTokenType.NFT,
+                          [GlyphProtocol.GLYPH_NFT])
+        if mark:
+            zone.is_companion = True
+            zone.parent_ref = idx._token_to_dict(name)["ref"]
+        _deploy(idx, db, name, zone, other)
+        return idx, db, name, zone
+
+    def test_write_path_omits_both_recency_rows(self):
+        _idx, db, _name, _zone = self._seed()
+        store = db.utxo_db._store
+        gq = [k for k in store if k.startswith(GlyphDBKeys.GLOBAL_RECENT)]
+        gz2 = [k for k in store if k.startswith(
+            GlyphDBKeys.BY_TYPE_RECENT + struct.pack("<B", GlyphTokenType.NFT))]
+        # GLOBAL_RECENT: the WAVE name + the standalone NFT, not the zone.
+        assert len(gq) == 2
+        # BY_TYPE_RECENT type 2: only the standalone NFT.
+        assert len(gz2) == 1
+        # ...but the protocol facet row survives, so nothing vanishes entirely.
+        gp = [k for k in store if k.startswith(
+            GlyphDBKeys.BY_PROTO + struct.pack("<B", GlyphProtocol.GLYPH_NFT))]
+        assert len(gp) == 3
+
+    def test_global_feed_has_no_nameless_companion(self):
+        idx, _db, _name, _zone = self._seed()
+        assert _names(idx.get_recent_tokens(limit=10)) == ["440000.rxd", "PLAIN"]
+
+    def test_by_type_recent_excludes_companion(self):
+        idx, _db, _name, _zone = self._seed()
+        r = idx.get_tokens_by_type(GlyphTokenType.NFT, order="recent")
+        assert _names(r) == ["PLAIN"]
+
+    def test_legacy_ref_order_still_enumerates_companion(self):
+        """order='ref' stays a complete enumeration — the row is curated out of
+        the *feeds*, not hidden from the index."""
+        idx, _db, _name, zone = self._seed()
+        r = idx.get_tokens_by_type(GlyphTokenType.NFT, order="ref")
+        assert len(r["tokens"]) == 2
+        assert any(t["is_companion"] for t in r["tokens"])
+        assert zone.ref.hex() in [t["ref_hex"] for t in r["tokens"]]
+
+    def test_companion_still_reachable_by_ref(self):
+        idx, _db, name, zone = self._seed()
+        got = idx.get_token(zone.ref)
+        assert got is not None and got.is_companion
+        assert got.parent_ref == idx._token_to_dict(name)["ref"]
+
+
+class TestCompanionLegacyRecordsFilteredOnRead:
+    """A DB indexed before the flag existed holds unmarked companion records
+    with live GQ/GZ rows. The read predicate re-derives the property so those
+    backends serve clean feeds with no reindex."""
+
+    def _seed_legacy(self):
+        # mark=False => flushed exactly as a pre-fix build would have.
+        idx, db, name, zone = TestCompanionExcludedFromRecencyFeeds()._seed(
+            mark=False)
+        return idx, db, name, zone
+
+    def test_legacy_rows_are_present_in_the_index(self):
+        _idx, db, _name, _zone = self._seed_legacy()
+        gq = [k for k in db.utxo_db._store
+              if k.startswith(GlyphDBKeys.GLOBAL_RECENT)]
+        assert len(gq) == 3  # the unmarked companion IS indexed
+
+    def test_read_predicate_hides_unmarked_companion(self):
+        idx, _db, _name, zone = self._seed_legacy()
+        assert zone.is_companion is False  # nothing rewrote the record
+        assert _names(idx.get_recent_tokens(limit=10)) == ["440000.rxd", "PLAIN"]
+        assert _names(idx.get_tokens_by_type(
+            GlyphTokenType.NFT, order="recent")) == ["PLAIN"]
+
+    def test_cursor_walk_over_filtered_rows_has_no_dupes(self):
+        idx, _db, _name, _zone = self._seed_legacy()
+        seen, cur = [], None
+        for _ in range(10):
+            p = idx.get_recent_tokens(limit=1, cursor=cur)
+            seen += _names(p)
+            cur = p["next_cursor"]
+            if cur is None:
+                break
+        assert seen == ["440000.rxd", "PLAIN"]
+
+
+class TestCompanionDerivationDoesNotOverReach:
+    """Guards on the legacy derivation: it must only catch plumbing."""
+
+    def test_standalone_bare_nft_at_vout_zero_is_kept(self):
+        idx, db = _make_index()
+        bare = _token_at(None, "bb" * 32, 0, 447900, GlyphTokenType.NFT,
+                         [GlyphProtocol.GLYPH_NFT], revealed=False)
+        _deploy(idx, db, bare)
+        assert idx._is_companion_singleton(bare) is False
+        assert len(idx.get_recent_tokens()["tokens"]) == 1
+
+    def test_bare_nft_with_no_vout_zero_sibling_is_kept(self):
+        idx, db = _make_index()
+        orphan = _token_at(None, "cc" * 32, 1, 447900, GlyphTokenType.NFT,
+                           [GlyphProtocol.GLYPH_NFT], revealed=False)
+        _deploy(idx, db, orphan)
+        assert idx._is_companion_singleton(orphan) is False
+
+    def test_bare_nft_whose_vout_zero_sibling_is_unnamed_is_kept(self):
+        idx, db = _make_index()
+        a = _token_at(None, "dd" * 32, 0, 447900, GlyphTokenType.NFT,
+                      [GlyphProtocol.GLYPH_NFT], revealed=False)
+        b = _token_at(None, "dd" * 32, 1, 447900, GlyphTokenType.NFT,
+                      [GlyphProtocol.GLYPH_NFT], revealed=False)
+        _deploy(idx, db, a, b)
+        assert idx._is_companion_singleton(b) is False
+
+    def test_revealed_sibling_is_kept(self):
+        idx, db = _make_index()
+        name, _zone = _wave_registration()
+        revealed = _token_at(None, WAVE_TXID, 1, 447893, GlyphTokenType.NFT,
+                             [GlyphProtocol.GLYPH_NFT], revealed=True)
+        _deploy(idx, db, name, revealed)
+        assert idx._is_companion_singleton(revealed) is False
+
+    def test_non_nft_sibling_is_kept(self):
+        """An FT minted at vout 1 alongside a named token is a real asset."""
+        idx, db = _make_index()
+        name, _zone = _wave_registration()
+        ft = _token_at(None, WAVE_TXID, 1, 447893, GlyphTokenType.FT,
+                       [GlyphProtocol.GLYPH_FT], revealed=False)
+        _deploy(idx, db, name, ft)
+        assert idx._is_companion_singleton(ft) is False
+
+
+class TestCompanionWriteDeleteSymmetry:
+    """_discovery_rows must stay a pure function of (ref, token) so write,
+    re-write dedup, delete and the v3->v4 migration derive the same key set."""
+
+    def test_migration_reproduces_the_same_exclusions(self):
+        idx, db = _make_index()
+        name, zone = _wave_registration()
+        zone.is_companion = True
+        # Seed GT rows only, as a v3 DB would have them.
+        store = db.utxo_db._store
+        for t in (name, zone):
+            store[pack_token_key(t.ref)] = t.to_bytes()
+        assert not any(k.startswith(GlyphDBKeys.GLOBAL_RECENT) for k in store)
+
+        idx._migrate_3_to_4()
+
+        gq = [k for k in store if k.startswith(GlyphDBKeys.GLOBAL_RECENT)]
+        assert len(gq) == 1  # the companion is not backfilled into the feed
+        assert _names(idx.get_recent_tokens()) == ["440000.rxd"]
+
+    def test_delete_removes_exactly_what_write_created(self):
+        idx, db = _make_index()
+        name, zone = _wave_registration()
+        zone.is_companion = True
+        _deploy(idx, db, name, zone)
+        store = db.utxo_db._store
+        before = set(store)
+
+        with db.utxo_db.write_batch() as batch:
+            for t in (name, zone):
+                idx._delete_discovery_rows(batch, t.ref, t, t.deploy_height)
+
+        # Every discovery row is gone; nothing orphaned, nothing left behind.
+        for pfx in (GlyphDBKeys.GLOBAL_RECENT, GlyphDBKeys.BY_TYPE_RECENT,
+                    GlyphDBKeys.BY_PROTO):
+            assert not any(k.startswith(pfx) for k in store)
+        assert before - set(store)  # it actually deleted something
+
+    def test_is_companion_survives_serialisation_round_trip(self):
+        _name, zone = _wave_registration()
+        zone.is_companion = True
+        zone.parent_ref = "abc_0"
+        back = GlyphTokenInfo.from_bytes(zone.to_bytes())
+        assert back.is_companion is True
+        assert back.parent_ref == "abc_0"
+
+    def test_absent_flag_defaults_false(self):
+        _name, zone = _wave_registration()
+        back = GlyphTokenInfo.from_bytes(zone.to_bytes())
+        assert back.is_companion is False

--- a/tests/server/test_glyph_api.py
+++ b/tests/server/test_glyph_api.py
@@ -335,3 +335,79 @@ class TestGetHeightForTx:
         """Mempool entries in blockchain.ref.get must use height=0"""
         mempool_entry = {'tx_hash': 'ff' * 32, 'height': 0}
         assert mempool_entry['height'] == 0
+
+
+class TestListLimitClamping:
+    """The v4 recency handlers were passing `limit` straight through to
+    _paginate_hydrated, which does a get_token DB read per scanned row — at
+    cost 2.0, and with hydration predicates that read rows without counting
+    them toward the page. Every sibling list handler in this module clamps."""
+
+    def test_clamps_to_max(self):
+        from electrumx.server.glyph_api import _clamp_list_limit, _MAX_LIST_LIMIT
+        assert _clamp_list_limit(10 ** 9) == _MAX_LIST_LIMIT
+        assert _clamp_list_limit(_MAX_LIST_LIMIT + 1) == _MAX_LIST_LIMIT
+
+    def test_passes_through_normal_values(self):
+        from electrumx.server.glyph_api import _clamp_list_limit
+        assert _clamp_list_limit(1) == 1
+        assert _clamp_list_limit(100) == 100
+        assert _clamp_list_limit(500) == 500
+
+    def test_floors_at_one(self):
+        """limit<=0 would make _paginate_hydrated return an empty page *with* a
+        cursor (it breaks on len(results) >= limit), which a paginating client
+        follows forever."""
+        from electrumx.server.glyph_api import _clamp_list_limit
+        assert _clamp_list_limit(0) == 1
+        assert _clamp_list_limit(-5) == 1
+
+    def test_non_numeric_falls_back_to_max(self):
+        from electrumx.server.glyph_api import _clamp_list_limit
+        assert _clamp_list_limit(None) == 500
+        assert _clamp_list_limit("abc") == 500
+
+    def test_numeric_string_is_coerced(self):
+        from electrumx.server.glyph_api import _clamp_list_limit
+        assert _clamp_list_limit("250") == 250
+
+
+@pytest.mark.asyncio
+class TestRecencyHandlersClampLimit:
+    """End-to-end: the handler must not hand an unbounded limit to the index."""
+
+    def _session(self):
+        from electrumx.server.glyph_api import GlyphAPIMixin
+
+        class _S(GlyphAPIMixin):
+            def __init__(self):
+                self.glyph_index = Mock()
+                self.glyph_index.get_recent_tokens = Mock(
+                    return_value={'tokens': [], 'next_cursor': None})
+                self.glyph_index.get_tokens_by_type = Mock(
+                    return_value={'tokens': [], 'next_cursor': None})
+
+            def bump_cost(self, _n):
+                pass
+
+        return _S()
+
+    async def test_get_recent_clamps(self):
+        s = self._session()
+        await s.glyph_get_recent(limit=10 ** 9)
+        assert s.glyph_index.get_recent_tokens.call_args.kwargs['limit'] == 500
+
+    async def test_get_recent_with_type_clamps(self):
+        s = self._session()
+        await s.glyph_get_recent(limit=10 ** 9, token_type=2)
+        assert s.glyph_index.get_tokens_by_type.call_args.kwargs['limit'] == 500
+
+    async def test_get_tokens_by_type_clamps(self):
+        s = self._session()
+        await s.glyph_get_tokens_by_type(token_type=2, limit=10 ** 9)
+        assert s.glyph_index.get_tokens_by_type.call_args.kwargs['limit'] == 500
+
+    async def test_zero_limit_becomes_one(self):
+        s = self._session()
+        await s.glyph_get_recent(limit=0)
+        assert s.glyph_index.get_recent_tokens.call_args.kwargs['limit'] == 1

--- a/tests/server/test_rest_api.py
+++ b/tests/server/test_rest_api.py
@@ -1100,3 +1100,178 @@ class TestQueryParamLengthBounds:
     def test_protocols_within_bound_accepted(self, client, mock_glyph_index):
         resp = client.get('/glyphs/search?q=x&protocols=1,2,3')
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /wave/names — bounded scan + gap-free pagination
+#
+# The endpoint post-filters the type-5 token list (duplicate registrations are
+# dropped after the index scan), so it must scan more rows than it emits. It
+# used to do that with a single get_tokens_by_type(limit=limit*3) call, which
+# (a) hydrated up to 6000 rows per request and (b) returned that page's
+# next_cursor even when the dedup loop broke partway through it — silently
+# skipping every name between the break point and row 3*limit.
+# ---------------------------------------------------------------------------
+
+class _FakeTypeIndex:
+    """Models get_tokens_by_type(order='ref') with inclusive-seek cursors.
+
+    Cursor == ref_hex of the first row to return (None = start), which is
+    exactly the contract cursor_for_type_ref relies on.
+    """
+
+    def __init__(self, tokens):
+        self.tokens = tokens
+        self.calls = []  # (limit, cursor) per call
+
+    def get_tokens_by_type(self, token_type, limit=100, cursor=None, order='ref'):
+        self.calls.append((limit, cursor))
+        start = 0
+        if cursor is not None:
+            start = next((i for i, t in enumerate(self.tokens)
+                          if t['ref_hex'] == cursor), len(self.tokens))
+        page = self.tokens[start:start + limit]
+        nxt = start + limit
+        return {
+            'tokens': page,
+            'next_cursor': (self.tokens[nxt]['ref_hex']
+                            if nxt < len(self.tokens) else None),
+        }
+
+    @staticmethod
+    def cursor_for_type_ref(token_type, ref):
+        return ref.hex()
+
+
+def _wave_token(name, i, canonical=True):
+    """A type-5 token row as _token_to_dict would render it."""
+    txid = f'{i:064x}'
+    dup_txid = f'{i + 900000:064x}'
+    return {
+        'ref': f'{txid}_0',
+        'ref_hex': txid + '00000000',
+        'attrs': {'name': name, 'domain': 'rxd', 'target': f'addr{i}'},
+        'deploy_txid': txid if canonical else dup_txid,
+        'deploy_height': 400000 + i,
+        'is_spent': False,
+    }
+
+
+def _wire_wave_names(monkeypatch, tokens):
+    """Point the endpoint's module globals at a fake index + wave index."""
+    import electrumx.server.rest_api as api
+
+    fake = _FakeTypeIndex(tokens)
+    wave = Mock()
+    # Canonical ref for a name = the txid of its canonical token, little-endian.
+    canon = {}
+    for t in tokens:
+        nm = t['attrs']['name']
+        if t['deploy_txid'] == t['ref_hex'][:64]:
+            canon[nm] = bytes.fromhex(t['deploy_txid'])[::-1] + b'\x00' * 4
+    wave._resolve_name_to_ref = Mock(side_effect=lambda n: canon.get(n))
+    wave._has_duplicates = Mock(return_value=False)
+
+    monkeypatch.setattr(api, '_glyph_index', fake)
+    monkeypatch.setattr(api, '_wave_index', wave)
+    return fake
+
+
+def _walk_wave_names(client, limit, max_pages=50):
+    """Follow next_cursor to exhaustion; return the full name list."""
+    out, cursor, pages = [], None, 0
+    while pages < max_pages:
+        pages += 1
+        q = f'/wave/names?limit={limit}'
+        if cursor:
+            q += f'&cursor={cursor}'
+        r = client.get(q)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        out += [n['full_name'] for n in body['names']]
+        cursor = body['next_cursor']
+        if cursor is None:
+            return out
+    raise AssertionError('pagination did not terminate')
+
+
+class TestWaveNamesPagination:
+
+    def test_walk_is_gap_free_and_dupe_free(self, client, monkeypatch):
+        """The regression: a mid-page break must resume at the first
+        unconsumed row, not past the whole scanned chunk."""
+        tokens = [_wave_token(f'n{i:03d}', i) for i in range(120)]
+        _wire_wave_names(monkeypatch, tokens)
+
+        got = _walk_wave_names(client, limit=10)
+
+        assert got == [f'n{i:03d}.rxd' for i in range(120)]
+        assert len(got) == len(set(got))
+
+    def test_duplicate_registrations_are_filtered_but_not_skipped(
+            self, client, monkeypatch):
+        """Non-canonical rows are dropped, and dropping them must not consume
+        canonical rows that follow."""
+        tokens = []
+        for i in range(60):
+            # Every canonical row is trailed by a duplicate registration of the
+            # same name at its own distinct ref.
+            tokens.append(_wave_token(f'n{i:03d}', 2 * i))
+            tokens.append(_wave_token(f'n{i:03d}', 2 * i + 1, canonical=False))
+        _wire_wave_names(monkeypatch, tokens)
+
+        got = _walk_wave_names(client, limit=7)
+
+        assert got == [f'n{i:03d}.rxd' for i in range(60)]
+
+    def test_scan_is_bounded_per_request(self, client, monkeypatch):
+        """No single request may hand an unbounded limit to the index."""
+        tokens = [_wave_token(f'n{i:04d}', i) for i in range(3000)]
+        fake = _wire_wave_names(monkeypatch, tokens)
+
+        r = client.get('/wave/names?limit=2000')
+        assert r.status_code == 200
+
+        assert fake.calls, 'index was never queried'
+        assert max(limit for limit, _c in fake.calls) <= 500
+
+    def test_scan_ceiling_still_returns_a_cursor(self, client, monkeypatch):
+        """A page cut short by the scan ceiling must not look like the end of
+        the list, or a walker silently loses the tail."""
+        # 6000 rows, none canonical => nothing is emitted, but there IS more.
+        tokens = [_wave_token(f'n{i:04d}', i, canonical=False)
+                  for i in range(6000)]
+        _wire_wave_names(monkeypatch, tokens)
+
+        body = client.get('/wave/names?limit=10').json()
+
+        assert body['names'] == []
+        assert body['next_cursor'] is not None
+
+    def test_exhausted_index_returns_null_cursor(self, client, monkeypatch):
+        tokens = [_wave_token(f'n{i}', i) for i in range(3)]
+        _wire_wave_names(monkeypatch, tokens)
+
+        body = client.get('/wave/names?limit=100').json()
+
+        assert [n['full_name'] for n in body['names']] == ['n0.rxd', 'n1.rxd', 'n2.rxd']
+        assert body['next_cursor'] is None
+
+    def test_empty_index(self, client, monkeypatch):
+        _wire_wave_names(monkeypatch, [])
+        body = client.get('/wave/names?limit=10').json()
+        assert body['names'] == []
+        assert body['next_cursor'] is None
+
+    def test_full_page_ending_exactly_on_chunk_boundary(self, client, monkeypatch):
+        """limit filled by the last row of a chunk: resume must come from the
+        index's own cursor, not a mid-page reconstruction."""
+        tokens = [_wave_token(f'n{i:03d}', i) for i in range(20)]
+        _wire_wave_names(monkeypatch, tokens)
+
+        got = _walk_wave_names(client, limit=20)
+        assert got == [f'n{i:03d}.rxd' for i in range(20)]
+
+    def test_limit_zero_is_rejected(self, client, monkeypatch):
+        _wire_wave_names(monkeypatch, [])
+        assert client.get('/wave/names?limit=0').status_code == 422


### PR DESCRIPTION
Three independent fixes to the Glyph discovery/list APIs, one commit each. Reviewable in order; each is green on its own.

## 1. `/wave/names` silently dropped 2/3 of the list (`c65b26c`)

The most user-visible bug here, and it is live today.

The endpoint over-fetched with `get_tokens_by_type(limit=limit*3)` to leave headroom for filtering out duplicate registrations, then `break`s once it has `limit` names — but returned *that page's* `next_cursor`, which points past all `3*limit` scanned rows. Everything between the break point and the end of the chunk was skipped on the next request.

Measured against the old code: walking 120 names at `limit=10` returned **40**, jumping `n009 -> n030 -> n060`. It finished with `next_cursor: null`, so a client could not tell the walk had been truncated.

The over-fetch was also unbounded work — `limit` is `le=2000`, so one request could hydrate 6000 rows, each a `get_token` read plus a wave-index lookup.

Fix: scan in 500-row chunks with a 5000-row per-request ceiling; new `GlyphIndex.cursor_for_type_ref` builds a resume cursor from the first *unconsumed* row. A page cut short by the ceiling still returns a cursor — `next_cursor` is `null` only when the index is genuinely exhausted.

## 2. WAVE registrations appeared twice in the discovery feed (`b9fd6a2`)

A registration mints two glyph outputs: the name singleton at vout 0 (type 5, named, protocols `[2,5,11]`) and its zone/mutable contract at vout 1, indexed as a token in its own right (type 2, `name: null`, protocols `[2]`). Verified on mainnet 2026-07-19: 28 of 28 registrations in a 60-row page had such a companion — **47% of the feed was plumbing**.

Cause is upstream of the discovery index: PHASE 1 registers every unseen ref as a token, but PHASE 2 enriches only the ref `_find_output_ref` returns (vout 0), so vout 1 stays bare. Not WAVE-specific — dMint deploys leak their mining-contract singletons the same way.

Reuses the already-on-chain-verified sibling rule from `_find_all_contract_refs`, extracted as `_find_sibling_singletons`. Companions are marked at reveal time and excluded from `GLOBAL_RECENT` and `BY_TYPE_RECENT`; a read-side predicate re-derives the property for records written before the flag existed, so **no reindex is required**.

## 3. Unclamped `limit` on the v4 recency handlers (`334bbde`)

`glyph.get_recent` / `glyph.get_tokens_by_type` passed `limit` straight into `_paginate_hydrated` (a `get_token` DB read per scanned row, at cost 2.0). Every sibling handler in the file already clamps. Now `1..500`, matching the REST side's `Query(le=500)`. Applied at the handler layer so internal callers keep their larger pages.

---

## Behavior changes for clients

- `glyph.get_recent` and `glyph.get_tokens_by_type(order: "recent")` return **fewer rows** — companions are gone. `order: "ref"` remains a complete enumeration.
- New row fields: `is_companion` and `parent_ref` (canonical `txid_vout`). Clients pairing a nameless type-2 row against a type-5 row by txid should drop that heuristic — it cannot work across a page boundary.
- `/wave/names`: a short page no longer means the walk is over. Follow `next_cursor` until it is `null`.

## Record correction on 423e020

`423e020` cited a launch-day report of a stale, half-hydrated global feed. **That report was retracted.** The reporting client had a parameter-parsing bug (`"".split(",").map(Number).filter(...)` yields `[0]`) and was passing `token_type=0`, so it was querying the UNKNOWN bucket and seeing its honest contents — nameless type-0 rows, newest far behind tip because UNKNOWN records are rare. The real all-types feed measured clean both before and after that fix.

Its UNKNOWN exclusion is **kept on its own merits** — `_discovery_rows` genuinely did index type-0 records into `GLOBAL_RECENT` — but not on that evidence. The commit's "per-backend skew from load-balanced backends" aside described a symptom that never happened; the host resolves to a single IP. Docstrings, a stale test comment, and `GLYPH_API.md` now record this so nobody hunts the phantom later.

## Testing

37 new tests. Each fix was mutation-tested — neutering the companion exclusion fails 6, removing the clamp fails 4, and 5 of the 8 `/wave/names` tests fail against the old implementation.

Full suite **963 passed** vs **926 on main**, with the same 10 pre-existing failures and 31 pre-existing errors (Mock fixtures / no event loop) throughout. Each commit was checked out and tested in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)