### PR TITLE
test: stop stubbing Env with Mock — fixes 24 broken tests, greens CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,16 @@ def _preserve_os_environ():
         os.environ.update(saved)
 
 
+from tests.support import FakeEnv  # noqa: E402  (re-exported for fixtures)
+
+
+@pytest.fixture
+def fake_env():
+    """A default :class:`~tests.support.FakeEnv`. Import the class directly
+    when a test needs to override a setting."""
+    return FakeEnv()
+
+
 # Verify that critical modules are available
 def pytest_configure(config):
     """Called after command line options have been parsed."""

--- a/tests/server/test_glyph_index.py
+++ b/tests/server/test_glyph_index.py
@@ -12,6 +12,8 @@ import pytest
 from unittest.mock import Mock, MagicMock
 import struct
 
+from tests.support import FakeEnv
+
 # Import the modules under test
 from electrumx.lib.glyph import (
     GLYPH_MAGIC,
@@ -412,11 +414,8 @@ class TestGlyphIndexIntegration:
 
     @pytest.fixture
     def mock_env(self):
-        """Create a mock environment."""
-        env = Mock()
-        env.glyph_index = True
-        env.reorg_limit = 10
-        return env
+        """A stand-in Env. Not a Mock — see FakeEnv in tests/conftest.py."""
+        return FakeEnv()
 
     def test_glyph_index_init(self, mock_db, mock_env):
         """Test GlyphIndex initialization."""
@@ -670,10 +669,7 @@ class TestDmintMintProcessing:
 
     @pytest.fixture
     def mock_env(self):
-        env = Mock()
-        env.glyph_index = True
-        env.reorg_limit = 10
-        return env
+        return FakeEnv()
 
     def test_process_mint_non_dmint_token_skipped(self, mock_db, mock_env):
         """Test that _process_mint skips non-dMint tokens."""
@@ -840,10 +836,7 @@ class TestImageExtraction:
         db.utxo_db.get = Mock(return_value=None)
         db.utxo_db.iterator = Mock(return_value=iter([]))
         db.db_height = 100
-        env = Mock()
-        env.glyph_index = True
-        env.reorg_limit = 10
-        return GlyphIndex(db, env)
+        return GlyphIndex(db, FakeEnv())
 
     def _make_reveal_envelope(self, cbor_payload: bytes) -> dict:
         """Build a minimal reveal envelope dict as produced by parse_glyph_envelope."""
@@ -1077,10 +1070,7 @@ class TestTokenToDictImages:
         db.utxo_db.get = Mock(return_value=None)
         db.utxo_db.iterator = Mock(return_value=iter([]))
         db.db_height = 100
-        env = Mock()
-        env.glyph_index = True
-        env.reorg_limit = 10
-        return GlyphIndex(db, env)
+        return GlyphIndex(db, FakeEnv())
 
     def _make_token_with_metadata(self, index, token_ref: bytes, metadata: dict):
         """Register a token and store its CBOR metadata in the index cache."""
@@ -1836,3 +1826,85 @@ class TestTokenDictJsonSafe:
         assert result['revealed_key'] == 'bb' * 32
         assert result['created_at'] is None
         assert result['reveal_height'] == 900
+
+
+# ---------------------------------------------------------------------------
+# Env stubbing contract + the dMint denylist path it used to break.
+#
+# GlyphIndex reads optional settings with getattr(env, name, default). A bare
+# Mock auto-creates every attribute as a truthy Mock, so the default never
+# applied and __init__ tried to iterate a Mock -- 24 tests across two files
+# died on "TypeError: 'Mock' object is not iterable" purely because their
+# fixtures never mentioned dmint_denylist. FakeEnv (tests/support.py) is a
+# plain object, so absent attributes really are absent.
+#
+# The denylist itself had no coverage, which is why the drift went unnoticed:
+# every test that touched it was failing in the constructor, so nothing ever
+# exercised what the setting does. These tests pin both.
+# ---------------------------------------------------------------------------
+
+class TestEnvStubContract:
+    def test_absent_attribute_falls_back_to_production_default(self):
+        """The property that makes FakeEnv safe: an unset setting is genuinely
+        unset, so getattr(env, name, default) yields the default."""
+        env = FakeEnv()
+        assert getattr(env, 'a_setting_that_does_not_exist', 'fallback') == 'fallback'
+        with pytest.raises(AttributeError):
+            env.a_setting_that_does_not_exist
+
+    def test_mock_env_would_not_fall_back(self):
+        """Contrast, pinning why a Mock must not be used here. If this ever
+        stops holding, the Mock-vs-FakeEnv distinction is moot."""
+        assert getattr(Mock(), 'anything', 'fallback') != 'fallback'
+
+    def test_defaults_mirror_a_real_env(self):
+        env = FakeEnv()
+        assert env.glyph_index is True
+        assert env.dmint_denylist == set()
+
+    def test_overrides_apply(self):
+        env = FakeEnv(glyph_index=False, reorg_limit=3)
+        assert env.glyph_index is False
+        assert env.reorg_limit == 3
+
+
+class TestDmintDenylist:
+    def _db(self):
+        db = Mock()
+        db.utxo_db = MagicMock()
+        db.utxo_db.get = Mock(return_value=None)
+        db.utxo_db.iterator = Mock(return_value=iter([]))
+        db.db_height = 100
+        return db
+
+    def test_empty_denylist_by_default(self):
+        from electrumx.server.glyph_index import GlyphIndex
+        index = GlyphIndex(self._db(), FakeEnv())
+        assert index._dmint_denylist == set()
+
+    def test_display_form_ref_is_parsed(self):
+        from electrumx.server.glyph_index import GlyphIndex, pack_ref
+        from electrumx.lib.hash import hex_str_to_hash
+        txid_hex = 'ab' * 32
+        index = GlyphIndex(self._db(), FakeEnv(dmint_denylist={f'{txid_hex}_0'}))
+        assert index._dmint_denylist == {pack_ref(hex_str_to_hash(txid_hex), 0)}
+
+    def test_raw_72_hex_form_is_parsed(self):
+        from electrumx.server.glyph_index import GlyphIndex
+        raw = 'cd' * 36  # 36 bytes = internal-order txid + LE vout
+        index = GlyphIndex(self._db(), FakeEnv(dmint_denylist={raw}))
+        assert index._dmint_denylist == {bytes.fromhex(raw)}
+
+    def test_invalid_ref_is_skipped_not_fatal(self):
+        """A bad entry must not take the indexer down at startup."""
+        from electrumx.server.glyph_index import GlyphIndex
+        good = 'ef' * 32 + '_1'
+        index = GlyphIndex(self._db(), FakeEnv(
+            dmint_denylist={good, 'not-a-ref', ''}))
+        assert len(index._dmint_denylist) == 1
+
+    def test_multiple_entries(self):
+        from electrumx.server.glyph_index import GlyphIndex
+        refs = {'aa' * 32 + '_0', 'bb' * 32 + '_2', 'cc' * 32 + '_1'}
+        index = GlyphIndex(self._db(), FakeEnv(dmint_denylist=refs))
+        assert len(index._dmint_denylist) == 3

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,53 @@
+"""Shared test helpers.
+
+A normal importable module rather than a conftest so both ``tests/`` and
+``tests/server/`` can import the same objects by a stable path
+(``from tests.support import FakeEnv``). ``pytest.ini`` puts the project root
+on ``sys.path`` via ``pythonpath = ..``, so that path resolves the same way
+regardless of which directory a test lives in.
+"""
+
+
+class FakeEnv:
+    """Minimal stand-in for ``electrumx.server.env.Env`` for index constructors.
+
+    Deliberately a plain object rather than a ``Mock``. The index classes read
+    optional settings with ``getattr(env, name, default)``, and a bare ``Mock``
+    auto-creates *every* attribute as a truthy ``Mock`` — so the default never
+    applies and the code receives a ``Mock`` where it expected a set, int or
+    bool. That is what broke ``GlyphIndex.__init__``, which does::
+
+        raw_denylist = getattr(env, 'dmint_denylist', set())
+        if raw_denylist:
+            for ref_str in raw_denylist:
+
+    Correct against a real ``Env`` (``dmint_denylist`` is always a set, empty
+    by default), but against a fixture that never mentioned the setting it
+    raised ``TypeError: 'Mock' object is not iterable`` — the fixture was
+    silently promising a denylist the real Env would have left empty.
+
+    Here, attributes that were not passed genuinely do not exist, so
+    ``getattr`` falls back to the production default exactly as against a real
+    Env. A newly added optional setting therefore cannot retroactively break
+    these fixtures: the test env behaves like an Env where the operator set
+    nothing.
+
+    Defaults mirror ``Env``: glyph indexing on, empty denylist. ``reorg_limit``
+    is 10 rather than the coin default purely to keep test undo-window maths
+    small and readable. Pass keywords to override, or to add an attribute a
+    specific test needs::
+
+        FakeEnv()                                   # usable default
+        FakeEnv(glyph_index=False)                  # indexing disabled
+        FakeEnv(dmint_denylist={'ab' * 32 + '_0'})  # exercise the denylist path
+    """
+
+    def __init__(self, **overrides):
+        self.glyph_index = True
+        self.reorg_limit = 10
+        self.dmint_denylist = set()
+        for key, value in overrides.items():
+            setattr(self, key, value)
+
+    def __repr__(self):
+        return f'FakeEnv({self.__dict__!r})'

--- a/tests/test_dmint_bounds.py
+++ b/tests/test_dmint_bounds.py
@@ -25,6 +25,7 @@ from electrumx.lib.glyph import (
     DMINT_MAX_SCRIPTNUM,
     DMINT_MAX_TOTAL_SUPPLY,
 )
+from tests.support import FakeEnv
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +299,10 @@ def _fresh_token():
 
 
 def _indexer():
-    return GlyphIndex(db=Mock(db_height=0), env=Mock(glyph_index=True, reorg_limit=0))
+    # FakeEnv, not Mock: see tests/support.py — a Mock env auto-creates every
+    # attribute, so GlyphIndex's getattr(env, 'dmint_denylist', set()) default
+    # never applied and the constructor tried to iterate a Mock.
+    return GlyphIndex(db=Mock(db_height=0), env=FakeEnv(reorg_limit=0))
 
 
 class TestDeployContractStateIntegration:


### PR DESCRIPTION
CI has been red on `main` for its entire recent history — **10 failures + 14 errors**, all `TypeError: 'Mock' object is not iterable` from `glyph_index.py:565`.

## Not a production defect

`GlyphIndex` reads optional settings the normal way:

```python
raw_denylist = getattr(env, 'dmint_denylist', set())
if raw_denylist:
    for ref_str in raw_denylist:
```

Correct against a real `Env` — `dmint_denylist` is always a set, empty by default. But the fixtures passed a bare `Mock()`, and **a Mock auto-creates every attribute as a truthy Mock**, so the default never applied and the constructor tried to iterate a Mock. The fixtures were silently promising a denylist the real Env would have left empty.

That means adding the setting to `Env` was enough to break every test that constructs a `GlyphIndex`, without anyone touching those tests.

## Fix the stub, not the production code

Hardening the loop against non-iterables would be production code apologising for a test defect, and would leave the same trap set for the next optional setting.

- **`tests/support.py`** — `FakeEnv`, a plain object rather than a Mock. Attributes that were not passed genuinely do not exist, so `getattr` falls back to the production default exactly as against a real Env. A newly added optional setting can no longer retroactively break these fixtures. It is a normal module rather than a conftest so `tests/` and `tests/server/` share one stable import path (`pytest.ini` already sets `pythonpath = ..`).
- Replaced the four Mock env sites in `test_glyph_index.py` and the one in `test_dmint_bounds.py`. The three `GlyphIndex.__new__` sites bypass `__init__` and are untouched.
- `conftest.py` re-exports `FakeEnv` and adds a `fake_env` fixture.

## Bonus: the denylist had zero coverage

Which is exactly why this drift went unnoticed for so long — every test that touched the setting was dying in the constructor, so nothing ever exercised what it does. Added tests for both accepted ref forms (display `txid_vout` and raw 72-hex), that an invalid entry is skipped rather than killing startup at boot, and the env-stub contract itself — including one test pinning the Mock behaviour that makes `FakeEnv` necessary, so the rationale cannot silently rot.

Verified the denylist tests fail when ref parsing is neutered.

## Result

Local: **996 passed, 0 failed** (was 987 passed / 10 failed / 14 env errors). The remaining 17 `test_daemon` errors are a Python 3.9-only event-loop issue and do not occur on CI's 3.10–3.12 — confirmed against the CI logs, where all 14 errors were `TestImageExtraction` + `TestTokenToDictImages`.

**Zero production files changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)