### PR TITLE
HashMark digest index, glyph discovery indexes (containers, creators, media, wildcard search), REST rate-limit exemptions

### DIFF
--- a/electrumx/lib/glyph.py
+++ b/electrumx/lib/glyph.py
@@ -506,6 +506,8 @@ def get_token_type_id(protocols: List[int],
     if GlyphProtocol.GLYPH_NFT in protocols:
         if GlyphProtocol.GLYPH_WAVE in protocols:
             return GlyphTokenType.WAVE
+        # CONTAINER is checked before AUTHORITY so a container+authority token
+        # ([2,7,10]) classifies the same way here as in get_token_type.
         if GlyphProtocol.GLYPH_CONTAINER in protocols:
             return GlyphTokenType.CONTAINER
         if GlyphProtocol.GLYPH_AUTHORITY in protocols:

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -83,6 +83,14 @@ except ImportError:
     HAS_ROYALTY_INDEX = False
     RoyaltyIndex = None
 
+# Import HashMarkIndex for HashMark digest lookups
+try:
+    from electrumx.server.hashmark_index import HashMarkIndex
+    HAS_HASHMARK_INDEX = True
+except ImportError:
+    HAS_HASHMARK_INDEX = False
+    HashMarkIndex = None
+
 try:
     from electrumx.server.analytics_index import AnalyticsIndex
     HAS_ANALYTICS_INDEX = True
@@ -264,6 +272,8 @@ class BlockProcessor:
         self.reorg_count = None
         self.height = -1
         self.tip = None
+        # Hash of the block currently being advanced; set by _advance_block for advance_txs.
+        self._block_hash = None
         self.tx_count = 0
         self._caught_up_event = None
 
@@ -317,6 +327,11 @@ class BlockProcessor:
         if HAS_ROYALTY_INDEX and getattr(env, 'royalty_index', False):
             self.royalty_index = RoyaltyIndex(db, env)
             self.logger.info('Royalty-listing (RRYL) discovery indexing initialized')
+        # HashMark digest indexing (backfilled from the daemon on first enable)
+        self.hashmark_index = None
+        if HAS_HASHMARK_INDEX and getattr(env, 'hashmark_index', False):
+            self.hashmark_index = HashMarkIndex(db, env)
+            self.logger.info('HashMark digest indexing initialized')
         self.analytics_index = None
         if HAS_ANALYTICS_INDEX and getattr(env, 'analytics_index', True):
             self.analytics_index = AnalyticsIndex(db, env)
@@ -388,6 +403,7 @@ class BlockProcessor:
                 swap_index=self.swap_index,
                 predict_index=self.predict_index,
                 royalty_index=self.royalty_index,
+                hashmark_index=self.hashmark_index,
                 analytics_index=self.analytics_index,
                 dmint_contracts=self.dmint_contracts,
             )
@@ -475,6 +491,7 @@ class BlockProcessor:
                          swap_index=self.swap_index,
                          predict_index=self.predict_index,
                          royalty_index=self.royalty_index,
+                         hashmark_index=self.hashmark_index,
                          analytics_index=self.analytics_index,
                          dmint_contracts=self.dmint_contracts)
         # Invalidate cached balances for any addresses touched by this flush.
@@ -528,6 +545,8 @@ class BlockProcessor:
             index_cache_size += self.predict_index.memory_estimate()
         if self.royalty_index is not None:
             index_cache_size += self.royalty_index.memory_estimate()
+        if self.hashmark_index is not None:
+            index_cache_size += self.hashmark_index.memory_estimate()
         if self.analytics_index is not None:
             index_cache_size += self.analytics_index.memory_estimate()
         utxo_MB = (db_deletes_size + utxo_cache_size) // one_MB
@@ -601,6 +620,11 @@ class BlockProcessor:
             self._current_block_time = 0
 
         is_unspendable = is_unspendable_legacy
+        # The HashMark index stores the block hash alongside every record, so make it available to
+        # advance_txs before the transactions are walked (it is the same hash used for self.tip
+        # below, so this costs no extra hashing).
+        block_hash = self.coin.header_hash(block.header)
+        self._block_hash = block_hash
         undo_info, ref_loc_undo_info = self.advance_txs(block.transactions, is_unspendable)
         if height >= min_height:
             self.undo_infos.append((undo_info, height))
@@ -609,7 +633,7 @@ class BlockProcessor:
 
         self.height = height
         self.headers.append(block.header)
-        self.tip = self.coin.header_hash(block.header)
+        self.tip = block_hash
 
         await sleep(0)
 
@@ -846,6 +870,20 @@ class BlockProcessor:
             append_hashXs(hashXs)
             update_touched(hashXs)
             update_touched(refs)
+
+            # HashMark digest records.  Deliberately outside the glyph_index guard below: a
+            # HashMark is a plain data output with no Glyph envelope, so it must still be indexed
+            # on a node running with GLYPH_INDEX=0.
+            if self.hashmark_index:
+                try:
+                    self.hashmark_index.process_tx(tx_hash, tx, self.height + 1, self._block_hash)
+                except MemoryError:
+                    raise
+                except Exception:
+                    self.logger.exception(
+                        'hashmark_index.process_tx failed for tx %s at height %d; skipping',
+                        hash_to_hex_str(tx_hash), self.height + 1
+                    )
 
             # Process transaction for Glyph tokens
             if self.glyph_index:
@@ -1350,6 +1388,9 @@ class BlockProcessor:
                 await group.spawn(self._process_blocks())
                 if self.analytics_index and self.height >= 0:
                     await group.spawn(self.analytics_index.backfill(self.height, caught_up_event))
+                if self.hashmark_index and self.height >= 0:
+                    await group.spawn(self.hashmark_index.backfill(
+                        self.height, self.daemon, caught_up_event))
 
                 async for task in group:
                     if not task.cancelled():

--- a/electrumx/server/controller.py
+++ b/electrumx/server/controller.py
@@ -147,6 +147,7 @@ class Controller(ServerBase):
                     wave_index=getattr(bp, 'wave_index', None),
                     swap_index=getattr(bp, 'swap_index', None),
                     royalty_index=getattr(bp, 'royalty_index', None),
+                    hashmark_index=getattr(bp, 'hashmark_index', None),
                     analytics_index=getattr(bp, 'analytics_index', None),
                     dmint_contracts=getattr(bp, 'dmint_contracts', None),
                     mempool=mempool,

--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -225,7 +225,7 @@ class DB(object):
         self.history.assert_flushed()
 
     def flush_dbs(self, flush_data, flush_utxos, estimate_txs_remaining,
-                  glyph_index=None, wave_index=None, realm_index=None, swap_index=None, predict_index=None, royalty_index=None, analytics_index=None, dmint_contracts=None):
+                  glyph_index=None, wave_index=None, realm_index=None, swap_index=None, predict_index=None, royalty_index=None, hashmark_index=None, analytics_index=None, dmint_contracts=None):
         '''Flush out cached state.  History is always flushed; UTXOs are
         flushed if flush_utxos. Glyph/WAVE/Swap indexes are flushed if provided.
         dMint contracts manager syncs from Glyph index if provided.'''
@@ -263,6 +263,8 @@ class DB(object):
                 predict_index.flush(batch)
             if royalty_index:
                 royalty_index.flush(batch)
+            if hashmark_index:
+                hashmark_index.flush(batch)
             if analytics_index:
                 analytics_index.flush(batch)
             self.flush_state(batch)
@@ -412,7 +414,7 @@ class DB(object):
         self.last_flush_tx_count = self.fs_tx_count
         self.write_utxo_state(batch)
 
-    def flush_backup(self, flush_data, touched, *, glyph_index=None, wave_index=None, realm_index=None, swap_index=None, predict_index=None, royalty_index=None, analytics_index=None, dmint_contracts=None):
+    def flush_backup(self, flush_data, touched, *, glyph_index=None, wave_index=None, realm_index=None, swap_index=None, predict_index=None, royalty_index=None, hashmark_index=None, analytics_index=None, dmint_contracts=None):
         '''Like flush_dbs() but when backing up.  All UTXOs are flushed.
         dMint contracts re-sync from Glyph index after reorg.'''
         assert not flush_data.headers
@@ -442,6 +444,8 @@ class DB(object):
                 predict_index.backup(batch, reorg_height)
             if royalty_index is not None:
                 royalty_index.backup(batch, reorg_height)
+            if hashmark_index is not None:
+                hashmark_index.backup(batch, reorg_height)
             if analytics_index is not None:
                 analytics_index.backup(batch, reorg_height)
             self.flush_utxo_db(batch, flush_data)

--- a/electrumx/server/env.py
+++ b/electrumx/server/env.py
@@ -103,6 +103,10 @@ class Env(EnvBase):
         # requires a reindex/backfill so historic listings populate (see
         # docs / RoyaltyIndex). Turn on with ROYALTY_INDEX=1 after deploy.
         self.royalty_index = False if minimal else self.boolean('ROYALTY_INDEX', False)
+        # HashMark digest index (hashmark.lookup).  Enabling it on an already-synced node kicks
+        # off a background historic backfill (see HashMarkIndex.backfill), which re-reads every
+        # block from the daemon once.  Set HASHMARK_INDEX=0 to skip it.
+        self.hashmark_index = False if minimal else self.boolean('HASHMARK_INDEX', True)
         self.analytics_index = False if minimal else self.boolean('ANALYTICS_INDEX', True)
         self.glyph_subscriptions = False if minimal else self.boolean('GLYPH_SUBSCRIPTIONS', True)
         self.mempool_glyph_index = False if minimal else self.boolean('MEMPOOL_GLYPH_INDEX', True)

--- a/electrumx/server/glyph_api.py
+++ b/electrumx/server/glyph_api.py
@@ -32,6 +32,13 @@ from electrumx.lib.glyph import (
 )
 from electrumx.lib.hash import hash_to_hex_str, hex_str_to_hash
 from electrumx.server.glyph_subscriptions import SubscriptionLimitError
+from electrumx.server.hashmark_index import (
+    DEFAULT_LIMIT as HASHMARK_DEFAULT_LIMIT,
+    MAX_LIMIT as HASHMARK_MAX_LIMIT,
+    parse_digest_arg as parse_hashmark_digest,
+    resolve_algorithm as resolve_hashmark_algorithm,
+)
+from electrumx.server.session import BAD_REQUEST, RPCError, non_negative_integer
 
 
 # Sentinel distinguishing "client did not pass cursor" (legacy list shape)
@@ -1239,6 +1246,52 @@ class GlyphAPIMixin:
         except Exception as e:
             return {'error': str(e)}
 
+    async def hashmark_lookup(self, digest: str, algorithm_id: Any = 1,
+                              limit: int = HASHMARK_DEFAULT_LIMIT):
+        """Find the confirmed HashMark records for one digest, oldest first.
+
+        Args:
+            digest: full lowercase hex digest, exactly the algorithm's length (sha256 -> 64 chars)
+            algorithm_id: algorithm id (1) or name ('sha256')
+            limit: maximum records to return (default 20, capped at 100)
+
+        Returns:
+            A list of records, oldest first — empty when the digest was never marked, which is a
+            normal answer rather than an error.  Each record carries txid/output_index/height/
+            block_hash/version/algorithm/digest, plus `label` when the mark had one.
+
+        A hit is a search hint, not proof: the caller is expected to re-fetch the transaction and
+        re-decode the output itself.
+        """
+        self.bump_cost(1.0)
+        if not self.hashmark_index:
+            raise RPCError(BAD_REQUEST, 'HashMark indexing not enabled on this server')
+
+        alg_id = resolve_hashmark_algorithm(algorithm_id)
+        if alg_id is None:
+            raise RPCError(BAD_REQUEST, f'{algorithm_id} is not a known HashMark algorithm')
+        digest_bytes = parse_hashmark_digest(digest, alg_id)
+        if digest_bytes is None:
+            # Deliberately strict: no prefix or partial matching, which would let a caller
+            # enumerate the index one nibble at a time.
+            raise RPCError(BAD_REQUEST,
+                           'digest must be the full lowercase hex digest for this algorithm')
+
+        limit = max(1, min(non_negative_integer(limit) or 1, HASHMARK_MAX_LIMIT))
+        self.bump_cost(0.05 * limit)
+        return self.hashmark_index.lookup(digest_bytes, alg_id, limit)
+
+    async def hashmark_stats(self):
+        """HashMark index status, including historic-backfill progress.
+
+        `backfill_complete` is what lets a client tell "this digest was never marked" from
+        "the index has not scanned that far back yet".
+        """
+        self.bump_cost(0.5)
+        if not self.hashmark_index:
+            raise RPCError(BAD_REQUEST, 'HashMark indexing not enabled on this server')
+        return self.hashmark_index.stats()
+
     async def swap_get_user_unconfirmed(self, scripthash: str):
         """
         Get unconfirmed swap orders for a user.
@@ -1713,6 +1766,9 @@ GLYPH_METHODS = {
     'market.list': 'market_list',
     # Royalty-listing discovery (RRYL beacons)
     'royalty.get_listings': 'royalty_get_listings',
+    # HashMark digest lookup
+    'hashmark.lookup': 'hashmark_lookup',
+    'hashmark.stats': 'hashmark_stats',
     # Mempool Glyph/Swap
     'glyph.get_unconfirmed_balance': 'glyph_get_unconfirmed_balance',
     'glyph.get_unconfirmed_txs': 'glyph_get_unconfirmed_txs',

--- a/electrumx/server/glyph_api.py
+++ b/electrumx/server/glyph_api.py
@@ -510,22 +510,40 @@ class GlyphAPIMixin:
 
     async def glyph_search_tokens(self, query: str, protocols: list = None,
                                    limit: int = 50,
-                                   cursor=_CURSOR_UNSET):
+                                   cursor=_CURSOR_UNSET,
+                                   wildcard: bool = False,
+                                   offset: int = 0):
         """
         Search tokens by name or ticker.
 
         Args:
-            query: Search query string
+            query: Search query. Exact by default. Contains ``*``/``?``/``[abc]`` -> wildcard
+                   search over BOTH name and ticker. Case-insensitive either way.
             protocols: Optional list of protocol IDs to filter
             limit: Maximum results
             cursor: Opaque pagination cursor (see docs/pagination-cursors.md).
                     When supplied, response shape is
-                    ``{entries, next_cursor, has_more}``.
+                    ``{entries, next_cursor, has_more}``. Not used by wildcard search,
+                    which pages with ``offset`` because its results are sorted
+                    alphabetically rather than by seek key.
+            wildcard: Force wildcard mode for plain text, treating ``query`` as
+                      ``*query*`` (substring). Ignored when query already has a metacharacter.
+            offset: Wildcard mode only: skip this many matches.
+
+        Exact search is an indexed hash lookup; wildcard search is a bounded full scan, because
+        BY_NAME stores sha256(name) and cannot be seeked by prefix. Wildcard responses carry
+        ``scanned``/``truncated`` so a caller can tell a complete answer from a capped one.
         """
         self.bump_cost(3.0)
 
         if not hasattr(self, 'glyph_index') or not self.glyph_index:
             return {'error': 'Glyph indexing not enabled'}
+
+        if wildcard or any(ch in (query or '') for ch in '*?['):
+            self.bump_cost(12.0)        # full scan, not a seek
+            return self.glyph_index.search_tokens_wildcard(
+                query, protocols=protocols, limit=limit, offset=offset,
+            )
 
         if cursor is _CURSOR_UNSET:
             return self.glyph_index.search_tokens(
@@ -656,6 +674,37 @@ class GlyphAPIMixin:
         return self.glyph_index.get_tokens_by_meta_type(
             'user', limit=min(limit, 500), cursor=cursor
         )
+
+    async def glyph_get_creator_works(self, creator_ref: str, limit: int = 100,
+                                      cursor: str = None):
+        """
+        Get all tokens attributed to a creator (metadata ``by`` field).
+
+        Args:
+            creator_ref: Creator token ref, "txid_vout" or 72-hex
+            limit: Maximum results (capped at 500)
+            cursor: Opaque pagination cursor from previous response next_cursor
+
+        Returns:
+            Dict with creator_ref, tokens list, and next_cursor.
+
+        Attribution is SELF-ASSERTED by whoever minted each token; nothing binds ``by`` to the
+        referenced token's owner. Entries are claims of authorship, not proof of it — the response
+        carries ``attribution: "self-asserted"`` as a standing reminder.
+        """
+        self.bump_cost(2.0)
+
+        if not hasattr(self, 'glyph_index') or not self.glyph_index:
+            return {'error': 'Glyph indexing not enabled'}
+
+        try:
+            from electrumx.server.glyph_index import parse_ref_any
+            ref_bytes = parse_ref_any(creator_ref)
+            return self.glyph_index.get_creator_works(
+                ref_bytes, limit=min(limit, 500), cursor=cursor
+            )
+        except Exception as e:
+            return {'error': str(e)}
 
     async def glyph_get_metadata(self, ref: str):
         """
@@ -1819,6 +1868,7 @@ GLYPH_METHODS = {
     # Container support
     'glyph.get_container_members': 'glyph_get_container_members',
     'glyph.list_containers': 'glyph_list_containers',
+    'glyph.get_creator_works': 'glyph_get_creator_works',
     # User profiles
     'glyph.list_users': 'glyph_list_users',
     # dMint contracts (for Glyph Miner)

--- a/electrumx/server/glyph_api.py
+++ b/electrumx/server/glyph_api.py
@@ -590,6 +590,73 @@ class GlyphAPIMixin:
             )
         return self.glyph_index.get_recent_tokens(limit=limit, cursor=cursor)
 
+    async def glyph_get_container_members(self, container_ref: str, limit: int = 100,
+                                           cursor: str = None):
+        """
+        Get all member tokens belonging to a container.
+
+        Args:
+            container_ref: Container token ref in format "txid_vout" or 72-hex
+            limit: Maximum results (capped at 500)
+            cursor: Opaque pagination cursor from previous response next_cursor
+
+        Returns:
+            Dict with container_ref, tokens list, and next_cursor
+        """
+        self.bump_cost(2.0)
+
+        if not hasattr(self, 'glyph_index') or not self.glyph_index:
+            return {'error': 'Glyph indexing not enabled'}
+
+        try:
+            from electrumx.server.glyph_index import parse_ref_any
+            ref_bytes = parse_ref_any(container_ref)
+            return self.glyph_index.get_container_members(
+                ref_bytes, limit=min(limit, 500), cursor=cursor
+            )
+        except Exception as e:
+            return {'error': str(e)}
+
+    async def glyph_list_containers(self, limit: int = 100, cursor: str = None):
+        """
+        List all container tokens.
+
+        Args:
+            limit: Maximum results (capped at 500)
+            cursor: Opaque pagination cursor from previous response next_cursor
+
+        Returns:
+            Dict with tokens list and next_cursor
+        """
+        self.bump_cost(2.0)
+
+        if not hasattr(self, 'glyph_index') or not self.glyph_index:
+            return {'error': 'Glyph indexing not enabled'}
+
+        return self.glyph_index.get_tokens_by_meta_type(
+            'container', limit=min(limit, 500), cursor=cursor
+        )
+
+    async def glyph_list_users(self, limit: int = 100, cursor: str = None):
+        """
+        List all user-profile tokens (metadata type == 'user').
+
+        Args:
+            limit: Maximum results (capped at 500)
+            cursor: Opaque pagination cursor from previous response next_cursor
+
+        Returns:
+            Dict with tokens list and next_cursor
+        """
+        self.bump_cost(2.0)
+
+        if not hasattr(self, 'glyph_index') or not self.glyph_index:
+            return {'error': 'Glyph indexing not enabled'}
+
+        return self.glyph_index.get_tokens_by_meta_type(
+            'user', limit=min(limit, 500), cursor=cursor
+        )
+
     async def glyph_get_metadata(self, ref: str):
         """
         Get full CBOR metadata for a token.
@@ -1749,6 +1816,11 @@ GLYPH_METHODS = {
     'glyph.get_tokens_by_type': 'glyph_get_tokens_by_type',
     'glyph.get_recent': 'glyph_get_recent',
     'glyph.get_metadata': 'glyph_get_metadata',
+    # Container support
+    'glyph.get_container_members': 'glyph_get_container_members',
+    'glyph.list_containers': 'glyph_list_containers',
+    # User profiles
+    'glyph.list_users': 'glyph_list_users',
     # dMint contracts (for Glyph Miner)
     'dmint.get_contracts': 'dmint_get_contracts',
     'dmint.get_contract': 'dmint_get_contract',

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -55,6 +55,8 @@ class GlyphDBKeys:
     UNDO = b'GXU'              # GXU + height(be) -> binary undo entries
     KEY_REVEALS = b'GKR'       # GKR + ref -> CBOR key reveal record (Phase 6 / REP-3009)
     CONTRACT_TO_TOKEN = b'GC'  # GC + contract_ref(36) -> token_ref(36) (R6 reverse index)
+    CONTAINER_MEMBERS = b'GCM' # GCM + container_ref(36) + member_ref(36) -> empty
+    BY_META_TYPE = b'GMT'      # GMT + type_hash(16) + ref(36) -> empty (metadata 'type' field index)
     STATS = b'GSTAT'           # GSTAT -> CBOR {total, ft, nft, dat, dmint, v1, v2} (R11)
     SCHEMA_VERSION = b'GVER'   # GVER -> uint8 schema version (R21)
     # --- v4 discovery indexes (recency-ordered; see _migrate_3_to_4) ---
@@ -74,7 +76,16 @@ class GlyphDBKeys:
 # v4: recency-ordered discovery indexes (BY_TYPE_RECENT / BY_PROTO / GLOBAL_RECENT).
 #     Backfillable in place from existing GT rows (deploy_height + protocols are
 #     already stored) — no radiantd rescan; see _migrate_3_to_4.
-CURRENT_SCHEMA_VERSION = 4
+# v5: container membership index (GCM keys). Backfillable in place from stored
+#     metadata (`in` field); see _migrate_4_to_5.
+# v6: metadata type index (GMT keys). Backfillable in place from stored metadata
+#     (`type` field); see _migrate_5_to_6.
+#
+# v5/v6 were developed as v4/v5 against a v3 base, before the recency indexes took
+# v4 upstream; they are renumbered here so the chain stays linear. Both derive
+# purely from the CBOR metadata already stored in GM rows, so neither needs the
+# full reindex their original notes assumed.
+CURRENT_SCHEMA_VERSION = 6
 
 
 # History event types
@@ -534,6 +545,14 @@ class GlyphIndex:
         self.contract_to_token_cache: Dict[bytes, bytes] = {}  # contract_ref -> token_ref
         self.contract_to_token_height: Dict[bytes, int] = {}   # contract_ref -> height
 
+        # Pending container membership index entries for flush
+        self.container_member_cache: Dict[bytes, Set[bytes]] = defaultdict(set)  # container_ref -> {member_ref}
+        self.container_member_height: Dict[bytes, int] = {}   # container_ref -> height
+
+        # Pending metadata type index entries for flush (GMT)
+        self.meta_type_cache: Dict[str, Set[bytes]] = defaultdict(set)  # meta_type_lower -> {ref}
+        self.meta_type_height: Dict[str, int] = {}            # meta_type_lower -> height
+
         # In-memory stats delta accumulator (R11)
         # Tracks net change in counts since last flush
         self._stats_delta: Dict[str, int] = dict(self._STATS_ZERO)
@@ -615,7 +634,9 @@ class GlyphIndex:
             return
 
         # v < CURRENT — walk the in-place migration chain.
-        migrations = {3: self._migrate_3_to_4}
+        migrations = {3: self._migrate_3_to_4,
+                      4: self._migrate_4_to_5,
+                      5: self._migrate_5_to_6}
         while v < CURRENT_SCHEMA_VERSION:
             migrator = migrations.get(v)
             if migrator is None:
@@ -687,6 +708,116 @@ class GlyphIndex:
             f'Glyph v4 migration complete: {total} tokens backfilled into '
             f'discovery indexes (GZ/GP/GQ)')
         return total
+
+    def _read_token_page(self, seek: bytes, page: int):
+        """Read one page of GT rows from ``seek``. Returns ``(items, next_seek)``.
+
+        ``items`` is ``[(ref, token)]`` with unparseable rows dropped; ``next_seek`` is None once
+        the walk is complete. The iterator is fully drained before returning, so a caller's
+        ``write_batch`` never overlaps an open RocksDB iterator — the same constraint
+        ``_migrate_3_to_4`` observes by collecting a page before opening its batch.
+        """
+        prefix = GlyphDBKeys.TOKEN
+        raw = []
+        for key, value in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            raw.append((key, value))
+            if len(raw) >= page:
+                break
+        items = []
+        for key, value in raw:
+            ref = key[len(prefix):]
+            if len(ref) != 36:
+                continue
+            try:
+                items.append((ref, GlyphTokenInfo.from_bytes(value)))
+            except Exception:
+                continue
+        # seek is inclusive, so resume strictly after the last key read.
+        next_seek = (raw[-1][0] + b'\x00') if len(raw) >= page else None
+        return items, next_seek
+
+    def _migrate_metadata_derived(self, label: str, derive) -> int:
+        """Shared driver for the v4->v5 and v5->v6 backfills.
+
+        Both walk existing GT rows, re-read each token's stored CBOR metadata from its GM row, and
+        write keys that are a pure function of that metadata — so neither needs a radiantd rescan
+        or any block reprocessing. ``derive(ref, metadata)`` returns the keys to write.
+
+        Notes (mirroring _migrate_3_to_4):
+          * Idempotent — the keys are derived, so re-writing them is a no-op and a run interrupted
+            before the version stamp is safe to repeat.
+          * Page-committed via ``seek``, never holding an iterator open across a commit.
+          * No undo recorded: migrations run at startup before block sync, so no reorg is
+            concurrent, and every list query hydrates via ``get_token`` and skips refs whose token
+            is gone — leaving any orphan inert.
+          * Tokens whose metadata is absent (never stored, or scrubbed by the dMint denylist) or
+            undecodable are skipped: there is nothing to derive a key from.
+        """
+        PAGE = 5000
+        seek = GlyphDBKeys.TOKEN
+        total = 0
+        indexed = 0
+        pages = 0
+        while True:
+            items, seek = self._read_token_page(seek, PAGE)
+            if items:
+                with self.db.utxo_db.write_batch() as batch:
+                    for ref, token in items:
+                        total += 1
+                        if not token.metadata_hash:
+                            continue
+                        metadata = self.get_metadata(token.metadata_hash)
+                        if not isinstance(metadata, dict):
+                            continue
+                        for key in derive(ref, metadata):
+                            batch.put(key, b'')
+                            indexed += 1
+                pages += 1
+                self.logger.info(
+                    f'Glyph {label} migration: {total} tokens scanned, '
+                    f'{indexed} rows written ({pages} page(s))')
+            if seek is None:
+                break
+        self.logger.info(
+            f'Glyph {label} migration complete: {indexed} rows written from {total} tokens')
+        return indexed
+
+    def _migrate_4_to_5(self) -> int:
+        """v4 -> v5: backfill the container membership index (GCM) in place.
+
+        Mirrors the live write path exactly: membership is declared by the MEMBER token, whose
+        metadata carries a 36-byte container ref at ``metadata['in'][0]`` (CBORTag-wrapped in some
+        encoders). Member tokens are plain NFTs and carry no distinguishing protocol flag, so the
+        ``in`` field is the sole signal.
+        """
+        def derive(ref, metadata):
+            in_field = metadata.get('in')
+            if not isinstance(in_field, (list, tuple)) or not in_field:
+                return
+            in_0 = in_field[0]
+            if hasattr(in_0, 'value'):      # unwrap CBORTag
+                in_0 = in_0.value
+            if isinstance(in_0, (bytes, bytearray)) and len(in_0) == 36:
+                yield GlyphDBKeys.CONTAINER_MEMBERS + bytes(in_0) + ref
+
+        return self._migrate_metadata_derived('v5 (GCM)', derive)
+
+    def _migrate_5_to_6(self) -> int:
+        """v5 -> v6: backfill the metadata type index (GMT) in place.
+
+        Mirrors the live write path exactly, including the ``strip().lower()`` normalisation — the
+        stored key is ``sha256(normalised_type)[:16]``, so any divergence here would produce keys
+        that live writes could never match.
+        """
+        def derive(ref, metadata):
+            raw_meta_type = metadata.get('type')
+            if raw_meta_type and isinstance(raw_meta_type, str):
+                meta_type_lower = raw_meta_type.strip().lower()
+                if meta_type_lower:
+                    type_hash = sha256(meta_type_lower.encode('utf-8'))[:16]
+                    yield GlyphDBKeys.BY_META_TYPE + type_hash + ref
+
+        return self._migrate_metadata_derived('v6 (GMT)', derive)
 
     def _scrub_denylist_metadata(self) -> None:
         """Delete stored CBOR metadata blobs (GM keys) for all denylisted tokens.
@@ -1574,6 +1705,34 @@ class GlyphIndex:
                     token.timelock_cek_hash = tl.get('cek_hash')  # 'sha256:hex'
                     token.timelock_hint = tl.get('hint')
 
+        # Extract container membership: presence of an 'in' field is sufficient —
+        # member tokens are plain NFTs and do not carry a specific container
+        # protocol flag.  The container ref is a 36-byte value at metadata['in'][0].
+        in_field = metadata.get('in')
+        if isinstance(in_field, (list, tuple)) and len(in_field) > 0:
+            in_0 = in_field[0]
+            # Unwrap CBORTag if needed
+            if hasattr(in_0, 'value'):
+                in_0 = in_0.value
+            if isinstance(in_0, (bytes, bytearray)) and len(in_0) == 36:
+                container_ref_bytes = bytes(in_0)
+                token.container_ref = container_ref_bytes.hex()
+                self.container_member_cache[container_ref_bytes].add(ref)
+                if container_ref_bytes not in self.container_member_height:
+                    self.container_member_height[container_ref_bytes] = height
+
+        # Index by metadata 'type' field (GMT) — covers application-level token
+        # categories like "user", "profile", etc. that are not expressed as
+        # protocol flags.  Both v1 (type string only) and v2 (p array + type
+        # string) tokens may carry this field.
+        raw_meta_type = metadata.get('type')
+        if raw_meta_type and isinstance(raw_meta_type, str):
+            meta_type_lower = raw_meta_type.strip().lower()
+            if meta_type_lower:
+                self.meta_type_cache[meta_type_lower].add(ref)
+                if meta_type_lower not in self.meta_type_height:
+                    self.meta_type_height[meta_type_lower] = height
+
         # Store in cache (GSTAT counting happens once at the GT write point in
         # flush(), covering all registration paths uniformly).
         self.token_cache[ref] = token
@@ -2066,6 +2225,23 @@ class GlyphIndex:
             self._record_undo(height, key)
             batch.put(key, token_ref)
 
+        # Flush container membership index (GCM + container_ref + member_ref -> empty)
+        for container_ref_bytes, member_refs in self.container_member_cache.items():
+            c_height = self.container_member_height.get(container_ref_bytes, self.db.db_height) or 0
+            for member_ref in member_refs:
+                key = GlyphDBKeys.CONTAINER_MEMBERS + container_ref_bytes + member_ref
+                self._record_undo(c_height, key)
+                batch.put(key, b'')
+
+        # Flush metadata type index (GMT + type_hash(16) + ref(36) -> empty)
+        for meta_type_str, refs in self.meta_type_cache.items():
+            type_hash = sha256(meta_type_str.encode('utf-8'))[:16]
+            mt_height = self.meta_type_height.get(meta_type_str, self.db.db_height) or 0
+            for ref in refs:
+                key = GlyphDBKeys.BY_META_TYPE + type_hash + ref
+                self._record_undo(mt_height, key)
+                batch.put(key, b'')
+
         # R11: Flush incremental stats counter
         self._flush_stats_counter(batch)
 
@@ -2088,6 +2264,10 @@ class GlyphIndex:
         self.key_reveal_height.clear()         # R2
         self.contract_to_token_cache.clear()   # R6
         self.contract_to_token_height.clear()  # R6
+        self.container_member_cache.clear()
+        self.container_member_height.clear()
+        self.meta_type_cache.clear()
+        self.meta_type_height.clear()
         self._stats_delta = dict(self._STATS_ZERO)  # R11
         self._known_refs.clear()               # R14: clear on every flush
     
@@ -2686,6 +2866,105 @@ class GlyphIndex:
         """
         prefix = GlyphDBKeys.BY_PROTO + struct.pack('<B', proto & 0xFF)
         return self._paginate_hydrated(prefix, limit, cursor)
+
+    def get_container_members(self, container_ref: bytes, limit: int = 100,
+                              cursor: Optional[str] = None) -> Dict[str, Any]:
+        """Get all member tokens belonging to a container, with cursor-based pagination."""
+        results = []
+        prefix = GlyphDBKeys.CONTAINER_MEMBERS + container_ref
+        seek = self._decode_cursor(cursor) or prefix
+        next_cursor = None
+
+        for key, _ in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            if len(results) >= limit:
+                next_cursor = self._encode_cursor(key)
+                break
+            member_ref = key[len(prefix):]
+            if len(member_ref) != 36:
+                continue
+            token = self.get_token(member_ref)
+            if token:
+                results.append(self._token_to_dict(token))
+
+        txid, vout = unpack_ref(container_ref)
+        return {
+            'container_ref': hash_to_hex_str(txid) + '_' + str(vout),
+            'tokens': results,
+            'next_cursor': next_cursor,
+        }
+
+    def has_container_members(self, container_ref: bytes) -> bool:
+        """Return True if any GCM entries exist for this container ref."""
+        prefix = GlyphDBKeys.CONTAINER_MEMBERS + container_ref
+        for _ in self.db.utxo_db.iterator(prefix=prefix):
+            return True
+        return False
+
+    def has_meta_type(self, meta_type: str, ref: bytes) -> bool:
+        """Return True if ref is indexed under the given metadata type."""
+        type_hash = sha256(meta_type.strip().lower().encode('utf-8'))[:16]
+        key = GlyphDBKeys.BY_META_TYPE + type_hash + ref
+        return self.db.utxo_db.get(key) is not None
+
+    def get_all_containers(self, limit: int = 100,
+                           cursor: Optional[str] = None) -> Dict[str, Any]:
+        """List containers that actually hold members, by scanning the GCM index.
+
+        This is deliberately narrower than ``get_tokens_by_type(CONTAINER)``.  A token carrying
+        GLYPH_CONTAINER (7) — or recovered by ``meta_indicates_container`` — is classified
+        CONTAINER and is discoverable through BY_TYPE whether or not anything is inside it.  This
+        scan instead walks GCM keys (GCM + container_ref + member_ref) and returns the unique
+        container_refs, so it yields only non-empty containers, in membership-index order.
+
+        Use BY_TYPE to enumerate every container; use this to enumerate the populated ones.
+        """
+        prefix = GlyphDBKeys.CONTAINER_MEMBERS
+        seek = self._decode_cursor(cursor) or prefix
+        next_cursor = None
+        results = []
+        last_container_ref = None
+
+        for key, _ in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            if len(key) < len(prefix) + 36:
+                continue
+            container_ref = key[len(prefix):len(prefix) + 36]
+            if container_ref == last_container_ref:
+                continue  # additional member of same container — skip
+            # New container encountered
+            if len(results) >= limit:
+                next_cursor = self._encode_cursor(key)
+                break
+            last_container_ref = container_ref
+            token = self.get_token(container_ref)
+            if token:
+                results.append(self._token_to_dict(token))
+
+        return {'tokens': results, 'next_cursor': next_cursor}
+
+    def get_tokens_by_meta_type(self, meta_type: str, limit: int = 100,
+                                cursor: Optional[str] = None) -> Dict[str, Any]:
+        """List tokens whose metadata carries a specific 'type' string (e.g. 'user').
+
+        Scans the GMT index (GMT + sha256(type_lower)[:16] + ref).
+        """
+        type_hash = sha256(meta_type.strip().lower().encode('utf-8'))[:16]
+        prefix = GlyphDBKeys.BY_META_TYPE + type_hash
+        seek = self._decode_cursor(cursor) or prefix
+        next_cursor = None
+        results = []
+
+        for key, _ in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            if len(results) >= limit:
+                next_cursor = self._encode_cursor(key)
+                break
+            ref = key[len(prefix):]
+            if len(ref) != 36:
+                continue
+            token = self.get_token(ref)
+            if token:
+                results.append(self._token_to_dict(token))
+
+        return {'tokens': results, 'next_cursor': next_cursor}
 
     def get_metadata(self, metadata_hash: bytes) -> Optional[Dict]:
         """Get parsed metadata by hash."""

--- a/electrumx/server/glyph_index.py
+++ b/electrumx/server/glyph_index.py
@@ -6,6 +6,7 @@ Handles token registration, balance tracking, and history.
 """
 
 import base64
+import os
 import struct
 from typing import Optional, Dict, Any, List, Tuple, Set
 from collections import defaultdict
@@ -57,6 +58,26 @@ class GlyphDBKeys:
     CONTRACT_TO_TOKEN = b'GC'  # GC + contract_ref(36) -> token_ref(36) (R6 reverse index)
     CONTAINER_MEMBERS = b'GCM' # GCM + container_ref(36) + member_ref(36) -> empty
     BY_META_TYPE = b'GMT'      # GMT + type_hash(16) + ref(36) -> empty (metadata 'type' field index)
+    # GA + creator_ref(36) + work_ref(36) -> empty. Answers "all glyphs by creator X" from the
+    # metadata `by` field.  Deliberately NOT 'GBY': that would sit under the BALANCE prefix 'GB',
+    # whose scans seek on GB + hashX(11) — a creator row would then be a candidate match for a
+    # hashX beginning 0x59 ('Y'). Same "no prefix may be a prefix of another" rule the recency
+    # indexes cite (and that GC/GCM and GM/GMT already bend).
+    BY_CREATOR = b'GA'
+    # GMH + sha256(media)(32) + token_ref(36) -> empty. Finds every token carrying the same media
+    # bytes, whether embedded (sha256 of main.b) or remote (the committed `h`), so the two forms of
+    # one artwork collide in a single keyspace.
+    #
+    # GMH does sit under METADATA's 'GM', but safely: every GM access is an exact `.get()` on
+    # GM + metadata_hash(32) and nothing ever prefix-scans 'GM' (same situation as the pre-existing
+    # GM/GMT pair).
+    MEDIA_HASH = b'GMH'
+    # GDH + metadata_hash(32) + ref(36) -> empty. Whole-payload clones: identical CBOR, not merely
+    # identical media. NOT 'GPH' as originally proposed — that sits under BY_PROTO's 'GP', which IS
+    # prefix-scanned as GP + proto(1), so a 'GPH' row would be a candidate match for protocol
+    # 0x48 (72). No protocol id is that high today, which is exactly what makes it a latent trap
+    # rather than a visible bug.
+    PAYLOAD_HASH = b'GDH'
     STATS = b'GSTAT'           # GSTAT -> CBOR {total, ft, nft, dat, dmint, v1, v2} (R11)
     SCHEMA_VERSION = b'GVER'   # GVER -> uint8 schema version (R21)
     # --- v4 discovery indexes (recency-ordered; see _migrate_3_to_4) ---
@@ -85,7 +106,16 @@ class GlyphDBKeys:
 # v4 upstream; they are renumbered here so the chain stays linear. Both derive
 # purely from the CBOR metadata already stored in GM rows, so neither needs the
 # full reindex their original notes assumed.
-CURRENT_SCHEMA_VERSION = 6
+# v7: creator attribution index (GA keys). Backfillable in place from stored metadata
+#     (`by` field); see _migrate_6_to_7.
+# v8: media-duplicate (GMH) and whole-payload-clone (GDH) indexes. Backfillable in place from
+#     stored metadata (embed bytes / remote `h`, and the metadata_hash already on each GT row);
+#     see _migrate_7_to_8.
+CURRENT_SCHEMA_VERSION = 8
+
+# Upper bound on GT rows examined by one wildcard search. The corpus is ~13k tokens today, so a
+# full pass is cheap; this exists so the cost stays bounded if it grows by orders of magnitude.
+MAX_WILDCARD_SCAN = int(os.getenv('GLYPH_MAX_WILDCARD_SCAN', '200000'))
 
 
 # History event types
@@ -118,6 +148,55 @@ def ref_to_display(ref: bytes) -> str:
     the raw 72-hex form) on input.
     """
     return hash_to_hex_str(ref[:32]) + '_' + str(struct.unpack('<I', ref[32:36])[0])
+
+
+def unwrap_cbor_bytes(value) -> Optional[bytes]:
+    """Unwrap a CBOR byte payload to raw bytes, or None.
+
+    Handles the shapes cbor2 hands back for embedded media: raw bytes/bytearray, or a CBORTag
+    (typed array, tag 64) whose ``.value`` is either bytes or a hex string.
+    """
+    if hasattr(value, 'value'):
+        value = value.value
+        if isinstance(value, str):
+            try:
+                return bytes.fromhex(value)
+            except ValueError:
+                return None
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    return None
+
+
+def media_hashes_from_metadata(metadata: Dict[str, Any]) -> Set[bytes]:
+    """Every 32-byte media hash a token's metadata commits to.
+
+    Embedded media contributes ``sha256(bytes)``; remote media contributes the committed ``h``
+    verbatim. Both are SINGLE sha256, deliberately: that is what a remote ``h`` already is, so an
+    embedded copy and a remote copy of one artwork land on the same key and collide in one index.
+
+    Candidate containers are classified by CONTENT, not key name — `main` may hold either an embed
+    (`b`) or a remote (`u`/`h`), which is why _token_to_dict already sniffs them this way. Unlike
+    the token-field extraction below, remote and embed are NOT mutually exclusive here: a token
+    carrying both should be findable by either hash.
+    """
+    out: Set[bytes] = set()
+    if not isinstance(metadata, dict):
+        return out
+    for key in ('main', 'preview', 'embed', 'em', 'remote', 'rm'):
+        section = metadata.get(key)
+        if not isinstance(section, dict):
+            continue
+        # Remote: a committed content hash, already a single sha256.
+        h = section.get('h')
+        if isinstance(h, (bytes, bytearray)) and len(h) == 32:
+            out.add(bytes(h))
+        # Embedded: hash the bytes ourselves. The 640 KiB CBOR payload cap
+        # (MAX_CBOR_PAYLOAD_BYTES) already bounds the work.
+        raw = unwrap_cbor_bytes(section.get('b'))
+        if raw:
+            out.add(sha256(raw))
+    return out
 
 
 def parse_ref_any(ref_str: str) -> bytes:
@@ -552,6 +631,12 @@ class GlyphIndex:
         # Pending metadata type index entries for flush (GMT)
         self.meta_type_cache: Dict[str, Set[bytes]] = defaultdict(set)  # meta_type_lower -> {ref}
         self.meta_type_height: Dict[str, int] = {}            # meta_type_lower -> height
+        self.creator_works_cache: Dict[bytes, Set[bytes]] = defaultdict(set)  # creator_ref -> {work_ref}
+        self.creator_works_height: Dict[bytes, int] = {}      # creator_ref -> height
+        self.media_hash_cache: Dict[bytes, Set[bytes]] = defaultdict(set)  # media_sha256 -> {ref}
+        self.media_hash_height: Dict[bytes, int] = {}         # media_sha256 -> height
+        self.payload_hash_cache: Dict[bytes, Set[bytes]] = defaultdict(set)  # metadata_hash -> {ref}
+        self.payload_hash_height: Dict[bytes, int] = {}       # metadata_hash -> height
 
         # In-memory stats delta accumulator (R11)
         # Tracks net change in counts since last flush
@@ -636,7 +721,9 @@ class GlyphIndex:
         # v < CURRENT — walk the in-place migration chain.
         migrations = {3: self._migrate_3_to_4,
                       4: self._migrate_4_to_5,
-                      5: self._migrate_5_to_6}
+                      5: self._migrate_5_to_6,
+                      6: self._migrate_6_to_7,
+                      7: self._migrate_7_to_8}
         while v < CURRENT_SCHEMA_VERSION:
             migrator = migrations.get(v)
             if migrator is None:
@@ -739,9 +826,11 @@ class GlyphIndex:
     def _migrate_metadata_derived(self, label: str, derive) -> int:
         """Shared driver for the v4->v5 and v5->v6 backfills.
 
-        Both walk existing GT rows, re-read each token's stored CBOR metadata from its GM row, and
-        write keys that are a pure function of that metadata — so neither needs a radiantd rescan
-        or any block reprocessing. ``derive(ref, metadata)`` returns the keys to write.
+        Each walks existing GT rows, re-reads the token's stored CBOR metadata from its GM row, and
+        writes keys that are a pure function of that metadata — so none needs a radiantd rescan or
+        any block reprocessing. ``derive(ref, metadata, metadata_hash)`` returns the keys to write;
+        the hash is passed because a derived key may need the payload's identity rather than its
+        contents (see _migrate_7_to_8).
 
         Notes (mirroring _migrate_3_to_4):
           * Idempotent — the keys are derived, so re-writing them is a no-op and a run interrupted
@@ -769,7 +858,7 @@ class GlyphIndex:
                         metadata = self.get_metadata(token.metadata_hash)
                         if not isinstance(metadata, dict):
                             continue
-                        for key in derive(ref, metadata):
+                        for key in derive(ref, metadata, token.metadata_hash):
                             batch.put(key, b'')
                             indexed += 1
                 pages += 1
@@ -790,7 +879,7 @@ class GlyphIndex:
         encoders). Member tokens are plain NFTs and carry no distinguishing protocol flag, so the
         ``in`` field is the sole signal.
         """
-        def derive(ref, metadata):
+        def derive(ref, metadata, _metadata_hash):
             in_field = metadata.get('in')
             if not isinstance(in_field, (list, tuple)) or not in_field:
                 return
@@ -809,7 +898,7 @@ class GlyphIndex:
         stored key is ``sha256(normalised_type)[:16]``, so any divergence here would produce keys
         that live writes could never match.
         """
-        def derive(ref, metadata):
+        def derive(ref, metadata, _metadata_hash):
             raw_meta_type = metadata.get('type')
             if raw_meta_type and isinstance(raw_meta_type, str):
                 meta_type_lower = raw_meta_type.strip().lower()
@@ -818,6 +907,45 @@ class GlyphIndex:
                     yield GlyphDBKeys.BY_META_TYPE + type_hash + ref
 
         return self._migrate_metadata_derived('v6 (GMT)', derive)
+
+    def _migrate_6_to_7(self) -> int:
+        """v6 -> v7: backfill the creator attribution index (GA) in place.
+
+        Mirrors the live write path: a 36-byte ref at ``metadata['by'][0]`` (CBORTag-wrapped in some
+        encoders). Note this backfills only the GA rows, not ``token.author`` on the GT record —
+        rewriting every token row to populate a display field is not worth a full rewrite pass, and
+        `get_creator_works` reads the GA index rather than the field. Tokens minted from here on
+        get both.
+        """
+        def derive(ref, metadata, _metadata_hash):
+            by_field = metadata.get('by')
+            if not isinstance(by_field, (list, tuple)) or not by_field:
+                return
+            by_0 = by_field[0]
+            if hasattr(by_0, 'value'):      # unwrap CBORTag
+                by_0 = by_0.value
+            if isinstance(by_0, (bytes, bytearray)) and len(by_0) == 36:
+                yield GlyphDBKeys.BY_CREATOR + bytes(by_0) + ref
+
+        return self._migrate_metadata_derived('v7 (GA)', derive)
+
+    def _migrate_7_to_8(self) -> int:
+        """v7 -> v8: backfill the media-duplicate (GMH) and payload-clone (GDH) indexes in place.
+
+        Both derive from what is already stored: GMH from the embedded bytes / remote ``h`` inside
+        the CBOR, GDH from the metadata_hash already on the GT row. No chain rescan.
+
+        Note this does NOT backfill ``token.embedded_data_hash`` for embed-only tokens (the live
+        path now sets it). Rewriting every GT row for a display field is not worth a full rewrite
+        pass, and the index — which is what queries read — is complete either way.
+        """
+        def derive(ref, metadata, metadata_hash):
+            for media_hash in media_hashes_from_metadata(metadata):
+                yield GlyphDBKeys.MEDIA_HASH + media_hash + ref
+            if metadata_hash:
+                yield GlyphDBKeys.PAYLOAD_HASH + metadata_hash + ref
+
+        return self._migrate_metadata_derived('v8 (GMH/GDH)', derive)
 
     def _scrub_denylist_metadata(self) -> None:
         """Delete stored CBOR metadata blobs (GM keys) for all denylisted tokens.
@@ -1675,13 +1803,30 @@ class GlyphIndex:
                 token.embedded_data_hash = bytes(h)
         elif embed and isinstance(embed, dict):
             token.icon_type = embed.get('t') or embed.get('type')
-            b = embed.get('b')
-            # CBORTag 64 = typed array; value may be hex str or bytes
-            if hasattr(b, 'value'):
-                b = bytes.fromhex(b.value) if isinstance(b.value, str) else b.value
-            if isinstance(b, (bytes, bytearray)):
+            b = unwrap_cbor_bytes(embed.get('b'))
+            if b:
                 token.icon_size = len(b)
                 token.icon_ref = 'embedded'
+                # Embedded media had no content hash on the token row until now — this field was
+                # only ever set from a REMOTE `h`, so embed-only tokens read back None. Populate it
+                # with the same single sha256 the GMH index keys on, so the row and the index can
+                # never disagree.
+                if token.embedded_data_hash is None:
+                    token.embedded_data_hash = sha256(b)
+
+        # Media-duplicate index (GMH): every media hash this token commits to, embedded or remote.
+        # Computed from the metadata directly rather than from the fields above, because those are
+        # mutually exclusive (`elif`) while a token carrying both should be findable by either.
+        for media_hash in media_hashes_from_metadata(metadata):
+            self.media_hash_cache[media_hash].add(ref)
+            if media_hash not in self.media_hash_height:
+                self.media_hash_height[media_hash] = height
+
+        # Whole-payload clone index (GDH): identical CBOR, not merely identical media.
+        if token.metadata_hash:
+            self.payload_hash_cache[token.metadata_hash].add(ref)
+            if token.metadata_hash not in self.payload_hash_height:
+                self.payload_hash_height[token.metadata_hash] = height
 
         # Encrypted content fields (Phase 6 / REP-3008)
         if GlyphProtocol.GLYPH_ENCRYPTED in token.protocols:
@@ -1720,6 +1865,26 @@ class GlyphIndex:
                 self.container_member_cache[container_ref_bytes].add(ref)
                 if container_ref_bytes not in self.container_member_height:
                     self.container_member_height[container_ref_bytes] = height
+
+        # Extract creator attribution (GA) from the metadata `by` field, mirroring `in` above:
+        # a 36-byte ref at metadata['by'][0] pointing at the creator's token.  This also finally
+        # populates `token.author`, which has been serialized ('au') and surfaced by the API since
+        # the beginning while never being assigned — so it always read back as None.
+        #
+        # Attribution is SELF-ASSERTED: `by` is a field the minter writes, with nothing binding it
+        # to the referenced token's owner.  A row here means "this token claims that creator", never
+        # that the creator agreed.  Callers must not present it as proof of authorship.
+        by_field = metadata.get('by')
+        if isinstance(by_field, (list, tuple)) and len(by_field) > 0:
+            by_0 = by_field[0]
+            if hasattr(by_0, 'value'):      # unwrap CBORTag
+                by_0 = by_0.value
+            if isinstance(by_0, (bytes, bytearray)) and len(by_0) == 36:
+                creator_ref_bytes = bytes(by_0)
+                token.author = creator_ref_bytes.hex()
+                self.creator_works_cache[creator_ref_bytes].add(ref)
+                if creator_ref_bytes not in self.creator_works_height:
+                    self.creator_works_height[creator_ref_bytes] = height
 
         # Index by metadata 'type' field (GMT) — covers application-level token
         # categories like "user", "profile", etc. that are not expressed as
@@ -2242,6 +2407,30 @@ class GlyphIndex:
                 self._record_undo(mt_height, key)
                 batch.put(key, b'')
 
+        # Flush creator attribution index (GA + creator_ref(36) + work_ref(36) -> empty)
+        for creator_ref_bytes, work_refs in self.creator_works_cache.items():
+            cr_height = self.creator_works_height.get(creator_ref_bytes, self.db.db_height) or 0
+            for work_ref in work_refs:
+                key = GlyphDBKeys.BY_CREATOR + creator_ref_bytes + work_ref
+                self._record_undo(cr_height, key)
+                batch.put(key, b'')
+
+        # Flush media-duplicate index (GMH + media_sha256(32) + ref(36) -> empty)
+        for media_hash, refs in self.media_hash_cache.items():
+            mh_height = self.media_hash_height.get(media_hash, self.db.db_height) or 0
+            for ref in refs:
+                key = GlyphDBKeys.MEDIA_HASH + media_hash + ref
+                self._record_undo(mh_height, key)
+                batch.put(key, b'')
+
+        # Flush whole-payload clone index (GDH + metadata_hash(32) + ref(36) -> empty)
+        for payload_hash, refs in self.payload_hash_cache.items():
+            ph_height = self.payload_hash_height.get(payload_hash, self.db.db_height) or 0
+            for ref in refs:
+                key = GlyphDBKeys.PAYLOAD_HASH + payload_hash + ref
+                self._record_undo(ph_height, key)
+                batch.put(key, b'')
+
         # R11: Flush incremental stats counter
         self._flush_stats_counter(batch)
 
@@ -2268,6 +2457,12 @@ class GlyphIndex:
         self.container_member_height.clear()
         self.meta_type_cache.clear()
         self.meta_type_height.clear()
+        self.creator_works_cache.clear()
+        self.creator_works_height.clear()
+        self.media_hash_cache.clear()
+        self.media_hash_height.clear()
+        self.payload_hash_cache.clear()
+        self.payload_hash_height.clear()
         self._stats_delta = dict(self._STATS_ZERO)  # R11
         self._known_refs.clear()               # R14: clear on every flush
     
@@ -2375,7 +2570,8 @@ class GlyphIndex:
             ref = pack_ref(hex_str_to_hash(txid), vout)
             token = self.get_token(ref)
             if token:
-                return self._token_to_dict(token)
+                # Detail path: opt into the media-reuse extras.
+                return self._token_to_dict(token, include_media_dupes=True)
         except Exception:
             pass
         return None
@@ -2906,6 +3102,181 @@ class GlyphIndex:
         key = GlyphDBKeys.BY_META_TYPE + type_hash + ref
         return self.db.utxo_db.get(key) is not None
 
+    def get_creator_works(self, creator_ref: bytes, limit: int = 100,
+                          cursor: Optional[str] = None) -> Dict[str, Any]:
+        """Tokens attributed to a creator, from the metadata ``by`` field.
+
+        Attribution is self-asserted by the minter and is not verified against the creator token's
+        owner — see the note at the GA write site. Treat entries as claims, not proof.
+        """
+        results = []
+        prefix = GlyphDBKeys.BY_CREATOR + creator_ref
+        seek = self._decode_cursor(cursor) or prefix
+        next_cursor = None
+
+        for key, _ in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            if len(results) >= limit:
+                next_cursor = self._encode_cursor(key)
+                break
+            work_ref = key[len(prefix):]
+            if len(work_ref) != 36:
+                continue
+            token = self.get_token(work_ref)
+            if token:
+                results.append(self._token_to_dict(token))
+
+        txid, vout = unpack_ref(creator_ref)
+        return {
+            'creator_ref': hash_to_hex_str(txid) + '_' + str(vout),
+            'attribution': 'self-asserted',
+            'tokens': results,
+            'next_cursor': next_cursor,
+        }
+
+    def get_tokens_by_media_hash(self, media_hash: bytes, limit: int = 100,
+                                 cursor: Optional[str] = None) -> Dict[str, Any]:
+        """Tokens whose media is byte-identical to ``media_hash``.
+
+        Covers embedded media (sha256 of the bytes) and remote media (the committed ``h``) in one
+        keyspace, so a re-upload of the same artwork is found regardless of how each token carries
+        it. Keys are not height-ordered — duplicate sets are small and each hydrated row carries
+        ``deploy_height``, so a caller sorts client-side to badge the first mint.
+        """
+        results = []
+        prefix = GlyphDBKeys.MEDIA_HASH + media_hash
+        seek = self._decode_cursor(cursor) or prefix
+        next_cursor = None
+
+        for key, _ in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            if len(results) >= limit:
+                next_cursor = self._encode_cursor(key)
+                break
+            ref = key[len(prefix):]
+            if len(ref) != 36:
+                continue
+            token = self.get_token(ref)
+            if token:
+                results.append(self._token_to_dict(token, include_embed_data=False))
+
+        return {
+            'media_sha256': media_hash.hex(),
+            'tokens': results,
+            'next_cursor': next_cursor,
+        }
+
+    def count_tokens_by_media_hash(self, media_hash: bytes, cap: int = 51) -> int:
+        """How many tokens share this media, counted key-only (no hydration).
+
+        Stops at ``cap`` so a hash reused thousands of times costs a bounded scan; callers render
+        a capped count as "50+".
+        """
+        prefix = GlyphDBKeys.MEDIA_HASH + media_hash
+        n = 0
+        for _ in self.db.utxo_db.iterator(prefix=prefix):
+            n += 1
+            if n >= cap:
+                break
+        return n
+
+    def get_tokens_by_payload_hash(self, payload_hash: bytes, limit: int = 100,
+                                   cursor: Optional[str] = None) -> Dict[str, Any]:
+        """Tokens whose ENTIRE CBOR payload is byte-identical — a whole-record clone."""
+        results = []
+        prefix = GlyphDBKeys.PAYLOAD_HASH + payload_hash
+        seek = self._decode_cursor(cursor) or prefix
+        next_cursor = None
+
+        for key, _ in self.db.utxo_db.iterator(prefix=prefix, seek=seek):
+            if len(results) >= limit:
+                next_cursor = self._encode_cursor(key)
+                break
+            ref = key[len(prefix):]
+            if len(ref) != 36:
+                continue
+            token = self.get_token(ref)
+            if token:
+                results.append(self._token_to_dict(token, include_embed_data=False))
+
+        return {
+            'payload_sha256': payload_hash.hex(),
+            'tokens': results,
+            'next_cursor': next_cursor,
+        }
+
+    def count_creator_works(self, creator_ref: bytes) -> int:
+        """Number of tokens attributed to a creator (key-only scan, no hydration)."""
+        prefix = GlyphDBKeys.BY_CREATOR + creator_ref
+        return sum(1 for _ in self.db.utxo_db.iterator(prefix=prefix))
+
+    def search_tokens_wildcard(self, pattern: str, protocols: List[int] = None,
+                               limit: int = 50, offset: int = 0,
+                               fields: Tuple[str, ...] = ('name', 'ticker')) -> Dict[str, Any]:
+        """Wildcard search over token name and ticker.
+
+        Supports shell-style patterns: ``*`` (any run), ``?`` (one char), ``[abc]`` (class).
+        A pattern with no wildcard is treated as ``*pattern*`` — a substring search, which is what
+        a search box means by typing three letters.  Matching is case-insensitive.
+
+        Why this is a full scan rather than an index seek: BY_NAME stores ``sha256(name)[:16]``, so
+        the on-disk name is one-way and admits exact equality only. No ordered index over hashed
+        keys can answer a prefix, let alone an infix, query. Ticker (``GK``) IS stored in the clear,
+        but a single scan that covers both fields keeps one code path and one result ordering.
+        Bounded by MAX_WILDCARD_SCAN so a pathological pattern cannot pin the event loop.
+        """
+        import fnmatch
+
+        pat = (pattern or '').strip().lower()
+        if not pat:
+            return {'tokens': [], 'count': 0, 'scanned': 0, 'truncated': False}
+        if not any(ch in pat for ch in '*?['):
+            pat = f'*{pat}*'          # bare text means substring, not exact
+
+        limit = max(1, min(int(limit), 200))
+        offset = max(0, int(offset))
+        want_name = 'name' in fields
+        want_ticker = 'ticker' in fields
+
+        matched = []
+        scanned = 0
+        truncated = False
+        prefix = GlyphDBKeys.TOKEN
+        for key, value in self.db.utxo_db.iterator(prefix=prefix):
+            if scanned >= MAX_WILDCARD_SCAN:
+                truncated = True
+                break
+            ref = key[len(prefix):]
+            if len(ref) != 36:
+                continue
+            scanned += 1
+            try:
+                token = GlyphTokenInfo.from_bytes(value)
+            except Exception:
+                continue
+            if protocols and not any(p in (token.protocols or []) for p in protocols):
+                continue
+            name = (token.name or '').lower()
+            ticker = (token.ticker or '').lower()
+            hit = ((want_name and name and fnmatch.fnmatchcase(name, pat))
+                   or (want_ticker and ticker and fnmatch.fnmatchcase(ticker, pat)))
+            if not hit:
+                continue
+            matched.append((name or ticker, ref, token))
+
+        # The scan deliberately runs to completion rather than stopping at offset+limit: results are
+        # ordered alphabetically, GT rows arrive in ref order, so an early break would sort only
+        # whichever matches happened to come first and page through a different set each call.
+        # Alphabetical so paging is stable across calls (GT order is by ref, i.e. arbitrary).
+        matched.sort(key=lambda m: (m[0], m[1]))
+        page = matched[offset:offset + limit]
+        return {
+            'pattern': pat,
+            'tokens': [self._token_to_dict(t) for _n, _r, t in page],
+            'count': len(page),
+            'has_more': len(matched) > offset + limit,
+            'scanned': scanned,
+            'truncated': truncated,
+        }
+
     def get_all_containers(self, limit: int = 100,
                            cursor: Optional[str] = None) -> Dict[str, Any]:
         """List containers that actually hold members, by scanning the GCM index.
@@ -2987,7 +3358,8 @@ class GlyphIndex:
     
     def _token_to_dict(self, token: GlyphTokenInfo, include_dmint: bool = True,
                         include_content: bool = True,
-                        include_embed_data: bool = True) -> Dict[str, Any]:
+                        include_embed_data: bool = True,
+                        include_media_dupes: bool = False) -> Dict[str, Any]:
         """
         Convert token info to API dict.
 
@@ -2997,6 +3369,12 @@ class GlyphIndex:
         page of icon-heavy tokens otherwise ships megabytes per page and blows
         the ElectrumX per-session bandwidth budget (the session gets dropped
         mid-pagination). Single-token endpoints keep the full payload.
+
+        ``include_media_dupes=True`` adds ``media_sha256`` and ``media_duplicates`` (a bounded
+        count of tokens sharing that media). DETAIL responses only, and off by default: the count
+        costs a GMH prefix scan per token, which on a 500-row list page would be 500 scans. A
+        client uses ``media_duplicates > 1`` as the trigger to fetch /media/{sha256}/glyphs, so it
+        never has to probe that endpoint speculatively.
         """
         txid, vout = unpack_ref(token.ref)
         
@@ -3134,6 +3512,22 @@ class GlyphIndex:
             result['is_wave_duplicate'] = token.is_wave_duplicate
             if token.is_wave_duplicate:
                 result['wave_warning'] = 'This is a DUPLICATE WAVE name registration. It is NOT used for name resolution. Only the first (canonical) registration is authoritative.'
+
+        # Media-reuse discovery (detail responses only — see include_media_dupes).
+        if include_media_dupes and token.embedded_data_hash:
+            try:
+                n = self.count_tokens_by_media_hash(token.embedded_data_hash)
+                # .hex(), NOT hash_to_hex_str: that reverses byte order for txid display, which
+                # would produce a string no client-computed sha256(file) could ever match. Matches
+                # what get_tokens_by_media_hash echoes back, so the two agree.
+                result['media_sha256'] = token.embedded_data_hash.hex()
+                # `capped` distinguishes "exactly 51" from "at least 51", so a client can render
+                # "50+" instead of a wrong exact figure.
+                result['media_duplicates'] = n
+                result['media_duplicates_capped'] = n >= 51
+            except Exception:
+                # A discovery extra must never break a token detail response.
+                self.logger.exception('media duplicate count failed for %s', token.ref.hex())
 
         # Several fields here are carried verbatim from the on-chain CBOR
         # metadata with no type coercion — `attrs` (an arbitrary NFT-attribute

--- a/electrumx/server/hashmark_index.py
+++ b/electrumx/server/hashmark_index.py
@@ -1,0 +1,616 @@
+"""
+HashMark digest index for RXinDexer (`hashmark.lookup`).
+
+Digest lookup is the one HashMark operation no existing Radiant infrastructure can serve:
+`blockchain.ref.get` indexes Glyph refs, not data-output payloads, and every other scanner in this
+tree is gated on its own magic (`gly`, `RMKT`, `RRYL`, `RSWP`) so a HashMark output leaves no trace
+in the DB.  This index closes that gap, which is what lets HashMark drop its separate indexer
+process rather than duplicating block-following, reorg handling and confirmation tracking.
+
+Record layout, an OP_RETURN of at most MAX_SCRIPT_BYTES.  Two versions are indexed::
+
+    v1 (HASHMARK_PROTOCOL.md) — 3 or 4 pushes
+      OP_RETURN
+        <push 8>  "HASHMARK"                      magic
+        <push 2>  version(uint8) || algorithmId(uint8)
+        <push N>  digest, N fixed by algorithmId  (sha256 = id 0x01, N = 32)
+        <push L>  label, OPTIONAL, 1..128 bytes UTF-8
+
+    v2 (docs/HASHMARK_V2_ATTESTATION.md) — 5 or 6 pushes
+      OP_RETURN
+        <push 8>  "HASHMARK"
+        <push 2>  version(0x02) || algorithmId
+        <push N>  digest
+        <push 20> signerHash160 — the key the record commits to
+        <push 65> compact recoverable signature over the canonical statement
+        <push L>  label, OPTIONAL, 1..88 bytes UTF-8 for sha256
+
+v2 moves the label from push 3 to push 5, which is exactly why an unknown version must never be
+read as a known one: a v1 parser let loose on a v2 record would index a signature as a label.
+
+The signature is NOT verified here.  Doing so needs secp256k1 and the chain's genesis hash, and
+would change nothing: HashMark re-fetches every hit and checks the signature against the committed
+signer itself.  A row is a pointer, and an unverified pointer is all this index has ever been.
+
+Detection is a 10-byte prefix compare (`HASHMARK_PREFIX`) run against every output, cheap enough
+that non-HashMark outputs — the overwhelming majority of OP_RETURNs on Radiant — cost one memcmp
+and are skipped silently.
+
+Key layout, one 'HMd' keyspace::
+
+    HMd + algorithmId(1) + digest(N) + be_u32(height) + txid(32) + be_u16(vout) -> version || block_hash || label
+
+The algorithm id leads the key so that digest length is fixed within any one prefix scan; a future
+algorithm with a different N therefore cannot make a shorter digest look like the prefix of a longer
+one.  Height precedes txid so a prefix iteration over (algorithm, digest) emerges in height-ascending
+order for free — the API returns oldest first because the earliest confirmed mark is the meaningful
+one.  txid+vout complete the key, giving each output exactly one row.
+
+Trust model: a hit means only "this script is on chain at this height", never that the digest
+describes what someone claims.  HashMark re-fetches and re-decodes every hit client-side and treats
+this index as a search hint, never as proof — so a bug here can cause a MISSED result but must never
+cause a false one.  That is why records carry the block hash they were mined in (§4): a row that
+somehow outlived its block is then detectable by the client rather than silently re-attributed to
+whatever block later occupies that height.
+"""
+
+import asyncio
+import os
+import re
+import struct
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from electrumx.lib import util
+from electrumx.lib.hash import hash_to_hex_str
+from electrumx.lib.util import pack_be_uint32, unpack_be_uint32, encode_undo, decode_undo
+
+MAGIC = b'HASHMARK'
+# OP_RETURN, push-8, "HASHMARK" — the whole detection test.
+HASHMARK_PREFIX = bytes([0x6A, 0x08]) + MAGIC
+
+V1 = 1
+V2 = 2
+SUPPORTED_VERSIONS = (V1, V2)
+# The version this index would expect a new record to use.  Kept separate from SUPPORTED_VERSIONS
+# because "what we can read" and "what is current" are different questions.
+LATEST_VERSION = V2
+
+# v2 fields, both fixed-length.
+SIGNER_HASH_BYTES = 20
+SIGNATURE_BYTES = 65
+
+# id -> (name, digest length in bytes)
+ALGORITHMS: Dict[int, Tuple[str, int]] = {0x01: ('sha256', 32)}
+ALGORITHM_IDS_BY_NAME = {name: alg_id for alg_id, (name, _n) in ALGORITHMS.items()}
+
+# v1 had no signature to pay for, so it could afford 40 more bytes of label.
+MAX_LABEL_BYTES_V1 = 128
+# v2, sha256: 223 - OP_RETURN(1) - magic(9) - header(3) - digest(33) - signer(21) - sig(66) - push(2)
+MAX_LABEL_BYTES_V2 = 88
+# The conservative relay ceiling both versions are designed against
+# (MAX_OP_RETURN_RELAY).  v1 records reach 176 bytes; v2 records reach exactly this.
+MAX_SCRIPT_BYTES = 223
+MAX_PUSH_BYTES = 520
+
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 100
+
+BACKFILL_CHUNK_BLOCKS = int(os.getenv('HASHMARK_BACKFILL_CHUNK_BLOCKS', '200'))
+
+_HEX_RE = re.compile(r'^[0-9a-f]+$')
+
+
+class HashMarkDBKeys:
+    """Database key prefixes for the HashMark index."""
+    DATA = b'HMd'               # see module docstring for the composite key layout
+    UNDO = b'HMu'               # HMu + be_u32(height) -> encode_undo([(key, None)])
+    LIVE_FROM = b'HMs'          # -> be_u32(first height covered by live indexing)
+    BACKFILL_CURSOR = b'HMc'    # -> be_u32(next height to scan)
+    BACKFILL_TARGET = b'HMt'    # -> be_u32(height the backfill scans up to, inclusive)
+    BACKFILL_DONE = b'HMf'      # -> b'1' once the historic scan has completed
+
+
+class HashMarkRecord:
+    """A parsed, validated HashMark output."""
+
+    __slots__ = ('version', 'algorithm_id', 'algorithm', 'digest', 'label',
+                 'signer_hash160')
+
+    def __init__(self, version: int, algorithm_id: int, algorithm: str,
+                 digest: bytes, label: Optional[str],
+                 signer_hash160: Optional[bytes] = None):
+        self.version = version
+        self.algorithm_id = algorithm_id
+        self.algorithm = algorithm
+        self.digest = digest          # raw bytes; hex only at the API boundary
+        self.label = label
+        # v2 only: the key the record commits to.  Stored so a client can tell two marks of one
+        # file apart without fetching both transactions.  Never verified here (see module docstring).
+        self.signer_hash160 = signer_hash160
+
+    def __eq__(self, other):
+        return (isinstance(other, HashMarkRecord)
+                and self.version == other.version
+                and self.algorithm_id == other.algorithm_id
+                and self.digest == other.digest
+                and self.label == other.label
+                and self.signer_hash160 == other.signer_hash160)
+
+    def __repr__(self):
+        return (f'HashMarkRecord(version={self.version}, algorithm={self.algorithm!r}, '
+                f'digest={self.digest.hex()!r}, label={self.label!r})')
+
+
+def read_pushes(script: bytes, offset: int) -> Optional[List[bytes]]:
+    """Read every push from `offset` to the end of `script`, or None if any is not minimal.
+
+    Minimal encoding is what gives a record exactly one valid serialization, so two independent
+    encoders produce identical bytes and records can be compared byte-for-byte.  OP_0 and
+    OP_1..OP_16 are rejected: they would give a one-byte field a second spelling.
+    """
+    pushes: List[bytes] = []
+    i = offset
+    n = len(script)
+    while i < n:
+        op = script[i]
+        i += 1
+        if 0x01 <= op <= 0x4b:
+            length = op
+        elif op == 0x4c:                            # OP_PUSHDATA1
+            if i >= n:
+                return None
+            length = script[i]
+            i += 1
+            if length <= 0x4b:
+                return None                         # non-minimal
+        elif op == 0x4d:                            # OP_PUSHDATA2
+            if i + 1 >= n:
+                return None
+            length = script[i] | (script[i + 1] << 8)
+            i += 2
+            if length <= 0xff:
+                return None                         # non-minimal
+        else:
+            return None                             # OP_0, OP_1..OP_16, OP_PUSHDATA4, …
+        if length > MAX_PUSH_BYTES or i + length > n:
+            return None
+        pushes.append(script[i:i + length])
+        i += length
+    return pushes
+
+
+def parse_hashmark(script: bytes) -> Union[HashMarkRecord, str]:
+    """Parse an output script.  Returns a HashMarkRecord, or a failure reason string.
+
+    ``NOT_HASHMARK`` means the output never claimed to be one (another protocol, or a
+    non-minimally-encoded magic push).  Every other reason means it claimed to be a HashMark and
+    failed validation — those are real, and are not indexed.
+    """
+    if not script or script[0] != 0x6A:
+        return 'NOT_HASHMARK'
+    pushes = read_pushes(script, 1)
+    if pushes is None or not pushes or pushes[0] != MAGIC:
+        return 'NOT_HASHMARK'
+
+    # From here the output claims to be a HashMark, so failures are real.
+    if len(script) > MAX_SCRIPT_BYTES:
+        return 'INVALID'
+    # The header has to be read before the shape can be checked: the push count and the position
+    # of the label both depend on the version.
+    if len(pushes) < 3 or len(pushes[1]) != 2:
+        return 'INVALID'
+
+    version, algorithm_id = pushes[1][0], pushes[1][1]
+    if version not in SUPPORTED_VERSIONS:
+        # Do NOT index an unknown version under a known version's rules: a later version may
+        # redefine every field after the header — v2 already moves the label from push 3 to push 5
+        # — so guessing would produce confidently wrong answers.
+        return 'UNKNOWN_VERSION'
+    if algorithm_id not in ALGORITHMS:
+        return 'UNKNOWN_ALGORITHM'
+
+    name, digest_len = ALGORITHMS[algorithm_id]
+    if len(pushes[2]) != digest_len:
+        return 'INVALID'
+
+    if version == V1:
+        expected, label_at, max_label = (3, 4), 3, MAX_LABEL_BYTES_V1
+    else:
+        expected, label_at, max_label = (5, 6), 5, MAX_LABEL_BYTES_V2
+    if len(pushes) not in expected:
+        return 'INVALID'
+
+    signer_hash160 = None
+    if version == V2:
+        if len(pushes[3]) != SIGNER_HASH_BYTES:
+            return 'INVALID'
+        if len(pushes[4]) != SIGNATURE_BYTES:
+            return 'INVALID'
+        signer_hash160 = pushes[3]
+
+    label = None
+    if len(pushes) > label_at:
+        raw = pushes[label_at]
+        # An empty label is unrepresentable: encoding one needs OP_0, which read_pushes rejects.
+        if len(raw) > max_label:
+            return 'INVALID'
+        try:
+            label = raw.decode('utf-8')             # strict: no replacement chars
+        except UnicodeDecodeError:
+            return 'INVALID'
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in label):
+            return 'INVALID'                        # control characters
+
+    return HashMarkRecord(version, algorithm_id, name, pushes[2], label, signer_hash160)
+
+
+def _data_key(record: HashMarkRecord, height: int, tx_hash: bytes, vout: int) -> bytes:
+    return (HashMarkDBKeys.DATA
+            + bytes([record.algorithm_id])
+            + record.digest
+            + pack_be_uint32(height)
+            + tx_hash
+            + struct.pack('>H', min(vout, 0xFFFF)))
+
+
+def _data_value(record: HashMarkRecord, block_hash: bytes) -> bytes:
+    """version(1) || block_hash(32) || [signer(20) when version >= 2] || label
+
+    The leading version byte is what makes this extensible in place: a row written before v2
+    existed says 1, so it is read the old way, and no rescan is needed to keep serving it.
+    """
+    label = record.label.encode('utf-8') if record.label else b''
+    signer = record.signer_hash160 if record.version >= V2 and record.signer_hash160 else b''
+    return bytes([record.version]) + block_hash + signer + label
+
+
+def _split_key(key: bytes, digest_len: int) -> Tuple[int, bytes, int]:
+    """Decode (height, tx_hash, vout) from the tail of a data key."""
+    pos = len(HashMarkDBKeys.DATA) + 1 + digest_len
+    height = unpack_be_uint32(key[pos:pos + 4])[0]
+    tx_hash = key[pos + 4:pos + 36]
+    vout = struct.unpack('>H', key[pos + 36:pos + 38])[0]
+    return height, tx_hash, vout
+
+
+def _split_value(raw: bytes) -> Tuple[int, bytes, Optional[str]]:
+    """Decode (version, block_hash, signer_hash160, label) from a stored value."""
+    version = raw[0]
+    block_hash = raw[1:33]
+    if version >= V2:
+        signer = raw[33:33 + SIGNER_HASH_BYTES]
+        label_raw = raw[33 + SIGNER_HASH_BYTES:]
+        if len(signer) != SIGNER_HASH_BYTES:
+            signer = None
+    else:
+        signer = None
+        label_raw = raw[33:]
+    label = label_raw.decode('utf-8', errors='replace') if label_raw else None
+    return version, block_hash, signer, label
+
+
+def scan_tx(tx_hash: bytes, tx, height: int, block_hash: bytes,
+            out: Dict[int, List[Tuple[bytes, bytes]]]) -> int:
+    """Add every valid HashMark output of `tx` to `out` (height -> [(key, value)]).
+
+    Shared by the live path and the backfill so both derive identical rows from identical scripts.
+    Returns the number of outputs indexed.
+    """
+    indexed = 0
+    for vout, txout in enumerate(tx.outputs):
+        script = txout.pk_script
+        if not script or not script.startswith(HASHMARK_PREFIX):
+            continue
+        record = parse_hashmark(script)
+        if isinstance(record, str):
+            continue        # claimed-but-invalid, or another protocol: not indexed
+        out.setdefault(height, []).append(
+            (_data_key(record, height, tx_hash, vout), _data_value(record, block_hash))
+        )
+        indexed += 1
+    return indexed
+
+
+class HashMarkIndex:
+    """Digest -> transaction index over HashMark OP_RETURN outputs."""
+
+    def __init__(self, db, env):
+        self.logger = util.class_logger(__name__, self.__class__.__name__)
+        self.db = db
+        self.env = env
+        self.enabled = getattr(env, 'hashmark_index', False)
+        # height -> [(key, value)] accumulated between flushes
+        self._pending: Dict[int, List[Tuple[bytes, bytes]]] = {}
+        self._pending_rows = 0
+        self._live_from: Optional[int] = None
+        reorg_limit = getattr(env, 'reorg_limit', 0)
+        cur = getattr(db, 'db_height', -1)
+        self._last_undo_pruned = (max(0, cur - reorg_limit + 1) - 1) if reorg_limit else -1
+
+    def set_logger(self, logger):
+        if logger:
+            self.logger = logger
+
+    # ---- block processing ----
+    def process_tx(self, tx_hash: bytes, tx, height: int, block_hash: bytes):
+        """Record every valid HashMark output of a confirmed transaction.
+
+        Mempool transactions are deliberately not indexed: an unconfirmed mark must never be
+        mistaken for a confirmed one, and every row here carries a real height and block hash.
+        """
+        if not self.enabled:
+            return
+        self._pending_rows += scan_tx(tx_hash, tx, height, block_hash, self._pending)
+
+    # ---- undo / flush / backup ----
+    def _undo_key(self, height: int) -> bytes:
+        return HashMarkDBKeys.UNDO + pack_be_uint32(height)
+
+    def _prune_old_undo_keys(self, batch):
+        reorg_limit = getattr(self.env, 'reorg_limit', 0)
+        if not reorg_limit:
+            return
+        prune_to = max(0, self.db.db_height - reorg_limit + 1) - 1
+        if prune_to <= self._last_undo_pruned:
+            return
+        for h in range(self._last_undo_pruned + 1, prune_to + 1):
+            batch.delete(self._undo_key(h))
+        self._last_undo_pruned = prune_to
+
+    def _record_live_from(self, batch):
+        """Persist, once, the first height this index covered live.
+
+        Everything from that height up arrives through process_tx, so only what lies BELOW it needs
+        a historic scan.  On a fresh sync db_height is -1 at the first flush, giving a watermark of
+        0 and an empty backfill range — which is what stops a from-genesis resync (as the DB_VERSIONS
+        bump in eec29a3 forces) from pointlessly re-reading the whole chain from the daemon.
+        """
+        if self._live_from is not None:
+            return
+        stored = self.db.utxo_db.get(HashMarkDBKeys.LIVE_FROM)
+        if stored:
+            self._live_from = unpack_be_uint32(stored)[0]
+            return
+        self._live_from = max(0, getattr(self.db, 'db_height', -1) + 1)
+        batch.put(HashMarkDBKeys.LIVE_FROM, pack_be_uint32(self._live_from))
+
+    def flush(self, batch):
+        if not self.enabled:
+            return
+        self._record_live_from(batch)
+        self._prune_old_undo_keys(batch)
+        for height, rows in self._pending.items():
+            try:
+                for key, value in rows:
+                    batch.put(key, value)
+                # Every row is a fresh insert — the key embeds txid+vout, so a height's rows can
+                # only ever be added, never overwritten.  Undo therefore just deletes them back out.
+                batch.put(self._undo_key(height), encode_undo([(key, None) for key, _v in rows]))
+            except Exception:
+                # Never let this overlay abort the shared write batch — that would halt every other
+                # indexer at this block.  Mirrors predict_index/swap_index flush discipline.
+                self.logger.exception('hashmark_index: skipping un-writable rows at height %d',
+                                      height)
+                continue
+        self._pending.clear()
+        self._pending_rows = 0
+
+    def backup(self, batch, height: int):
+        """Unwind one disconnected block: the table is a pure projection of chain data, so the
+        rows it wrote are simply deleted and re-added when the new chain is processed."""
+        if not self.enabled:
+            return
+        raw = self.db.utxo_db.get(self._undo_key(height))
+        if not raw:
+            return
+        for key, prev in decode_undo(raw):
+            if prev is None:
+                batch.delete(key)
+            else:
+                batch.put(key, prev)
+        batch.delete(self._undo_key(height))
+
+    def memory_estimate(self) -> int:
+        if not self.enabled:
+            return 0
+        return self._pending_rows * 260
+
+    # ---- backfill ----
+    def _backfill_state(self) -> Tuple[bool, int, int]:
+        """Return (done, next_height, target) from the on-disk checkpoint."""
+        done = bool(self.db.utxo_db.get(HashMarkDBKeys.BACKFILL_DONE))
+        cursor_raw = self.db.utxo_db.get(HashMarkDBKeys.BACKFILL_CURSOR)
+        target_raw = self.db.utxo_db.get(HashMarkDBKeys.BACKFILL_TARGET)
+        next_height = unpack_be_uint32(cursor_raw)[0] if cursor_raw else 0
+        target = unpack_be_uint32(target_raw)[0] if target_raw else -1
+        return done, next_height, target
+
+    def _backfill_target(self, height: int) -> int:
+        """Highest height the historic scan must cover: everything below where live indexing began.
+
+        Falls back to the current tip when no watermark exists yet — that is a node enabling the
+        index and reaching caught-up without having flushed a block, where nothing has been indexed
+        live and the whole chain does need scanning.
+        """
+        stored = self.db.utxo_db.get(HashMarkDBKeys.LIVE_FROM)
+        if stored:
+            return unpack_be_uint32(stored)[0] - 1
+        return height
+
+    async def backfill(self, height: int, daemon, caught_up_event=None):
+        """Scan historic blocks for HashMark outputs, resuming from the last checkpoint.
+
+        Unlike analytics_index's backfill this cannot read what it needs from the DB — ElectrumX
+        stores no raw scripts for unspendable outputs — so it re-reads blocks from the daemon.  It
+        runs as a background task after the node is caught up and serving, yields to the event loop
+        between chunks, and checkpoints after every chunk so an interrupted run resumes instead of
+        restarting.  Exceptions are logged, never propagated: a backfill failure must not kill the
+        block-processing task group.
+        """
+        if not self.enabled:
+            return
+        if caught_up_event is not None:
+            await caught_up_event.wait()
+        try:
+            await self._backfill_impl(height, daemon)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.exception('HashMark backfill failed; will resume on next startup')
+
+    async def _backfill_impl(self, height: int, daemon):
+        done, next_height, target = self._backfill_state()
+        if done:
+            return
+        if target < 0:
+            # First run: the scan stops exactly where live indexing began, so the two paths meet
+            # and leave neither gap nor overlap.  On a from-genesis sync that range is empty.
+            target = self._backfill_target(height)
+            if target < 0:
+                with self.db.utxo_db.write_batch() as batch:
+                    batch.put(HashMarkDBKeys.BACKFILL_DONE, b'1')
+                self.logger.info('HashMark index covered the chain live; no backfill needed')
+                return
+            with self.db.utxo_db.write_batch() as batch:
+                batch.put(HashMarkDBKeys.BACKFILL_TARGET, pack_be_uint32(target))
+                batch.put(HashMarkDBKeys.BACKFILL_CURSOR, pack_be_uint32(0))
+            next_height = 0
+            self.logger.info('Starting HashMark backfill: heights 0..%d', target)
+        else:
+            self.logger.info('Resuming HashMark backfill at height %d (target %d)',
+                             next_height, target)
+
+        # Backfilled blocks this close to the tip are still reorgable, so they need undo records
+        # exactly as live-indexed blocks do.
+        reorg_limit = getattr(self.env, 'reorg_limit', 0)
+        undo_from = max(0, target - reorg_limit + 1) if reorg_limit else target + 1
+
+        total_rows = 0
+        while next_height <= target:
+            count = min(BACKFILL_CHUNK_BLOCKS, target - next_height + 1)
+            hex_hashes = await daemon.block_hex_hashes(next_height, count)
+            raw_blocks = await daemon.raw_blocks(hex_hashes)
+
+            pending: Dict[int, List[Tuple[bytes, bytes]]] = {}
+            for offset, raw_block in enumerate(raw_blocks):
+                block_height = next_height + offset
+                try:
+                    block = self.env.coin.block(raw_block)
+                    block_hash = self.env.coin.header_hash(block.header)
+                except Exception:
+                    self.logger.exception('hashmark backfill: undecodable block at height %d',
+                                          block_height)
+                    continue
+                for tx, tx_hash in block.transactions:
+                    total_rows += scan_tx(tx_hash, tx, block_height, block_hash, pending)
+
+            with self.db.utxo_db.write_batch() as batch:
+                for h, rows in pending.items():
+                    for key, value in rows:
+                        batch.put(key, value)
+                    if h >= undo_from:
+                        existing = self.db.utxo_db.get(self._undo_key(h))
+                        merged = ((decode_undo(existing) if existing else [])
+                                  + [(key, None) for key, _v in rows])
+                        batch.put(self._undo_key(h), encode_undo(merged))
+                next_height += count
+                batch.put(HashMarkDBKeys.BACKFILL_CURSOR, pack_be_uint32(next_height))
+
+            self.logger.debug('HashMark backfill checkpoint: height %d/%d, %d records indexed',
+                              next_height - 1, target, total_rows)
+            await asyncio.sleep(0)
+
+        with self.db.utxo_db.write_batch() as batch:
+            batch.put(HashMarkDBKeys.BACKFILL_DONE, b'1')
+            batch.delete(HashMarkDBKeys.BACKFILL_CURSOR)
+        self.logger.info('HashMark backfill complete: %d records indexed up to height %d',
+                         total_rows, target)
+
+    # ---- queries ----
+    def lookup(self, digest: bytes, algorithm_id: int = 0x01,
+               limit: int = DEFAULT_LIMIT) -> List[Dict[str, Any]]:
+        """Return the marks for one digest, oldest first.  An empty list means no match — a
+        digest that was never marked is a normal answer, not an error."""
+        if algorithm_id not in ALGORITHMS:
+            return []
+        name, digest_len = ALGORITHMS[algorithm_id]
+        if len(digest) != digest_len:
+            return []
+        limit = max(1, min(int(limit), MAX_LIMIT))
+
+        prefix = HashMarkDBKeys.DATA + bytes([algorithm_id]) + digest
+        results: List[Dict[str, Any]] = []
+        # Keys sort height-ascending within a (algorithm, digest) prefix, so forward iteration is
+        # already oldest-first and stops as soon as the page is full.
+        for key, raw in self.db.utxo_db.iterator(prefix=prefix):
+            if len(raw) < 33:
+                continue
+            height, tx_hash, vout = _split_key(key, digest_len)
+            version, block_hash, signer, label = _split_value(raw)
+            entry = {
+                'txid': hash_to_hex_str(tx_hash),
+                'output_index': vout,
+                'height': height,
+                'block_hash': hash_to_hex_str(block_hash),
+                'version': version,
+                'algorithm': name,
+                'digest': digest.hex(),
+            }
+            # v2 only, and still only a hint: the client recovers the key from the signature and
+            # checks it against this commitment itself.
+            if signer is not None:
+                entry['signer_hash160'] = signer.hex()
+            if label is not None:
+                entry['label'] = label
+            results.append(entry)
+            if len(results) >= limit:
+                break
+        return results
+
+    def stats(self) -> Dict[str, Any]:
+        """Index status.  `backfill_complete` is what tells a client whether an empty lookup means
+        'never marked' or 'not scanned yet'."""
+        done, next_height, target = self._backfill_state()
+        return {
+            'enabled': self.enabled,
+            'backfill_complete': done,
+            'backfill_target_height': target if target >= 0 else None,
+            'backfill_next_height': None if done else next_height,
+            'pending_rows': self._pending_rows,
+            'algorithms': {name: alg_id for alg_id, (name, _n) in ALGORITHMS.items()},
+            # Kept for clients written against the v1-only index; `protocol_versions` is the
+            # honest answer now that more than one is readable.
+            'protocol_version': LATEST_VERSION,
+            'protocol_versions': list(SUPPORTED_VERSIONS),
+        }
+
+
+def parse_digest_arg(digest_hex: Any, algorithm_id: int) -> Optional[bytes]:
+    """Validate a client-supplied digest.
+
+    Only an exact, lowercase, full-length hex digest is accepted.  Prefix or partial matching is
+    deliberately not offered: it would let a caller enumerate the index.
+    """
+    if algorithm_id not in ALGORITHMS:
+        return None
+    _name, digest_len = ALGORITHMS[algorithm_id]
+    if not isinstance(digest_hex, str) or len(digest_hex) != digest_len * 2:
+        return None
+    if not _HEX_RE.match(digest_hex):
+        return None
+    return bytes.fromhex(digest_hex)
+
+
+def resolve_algorithm(algorithm: Any) -> Optional[int]:
+    """Accept either an algorithm id (1) or its name ('sha256'); None if unknown."""
+    if isinstance(algorithm, bool):
+        return None
+    if isinstance(algorithm, int):
+        return algorithm if algorithm in ALGORITHMS else None
+    if isinstance(algorithm, str):
+        if algorithm in ALGORITHM_IDS_BY_NAME:
+            return ALGORITHM_IDS_BY_NAME[algorithm]
+        if algorithm.isdigit():
+            alg_id = int(algorithm)
+            return alg_id if alg_id in ALGORITHMS else None
+    return None

--- a/electrumx/server/radiant_session.py
+++ b/electrumx/server/radiant_session.py
@@ -66,6 +66,13 @@ class RadiantElectrumX(GlyphAPIMixin, ElectrumX):
         return None
 
     @property
+    def hashmark_index(self):
+        """Access the HashMark digest index from block processor."""
+        if hasattr(self, 'session_mgr') and hasattr(self.session_mgr, 'bp'):
+            return getattr(self.session_mgr.bp, 'hashmark_index', None)
+        return None
+
+    @property
     def realm_index(self):
         """Access the realm (realm_v1) directory index from block processor."""
         if hasattr(self, 'session_mgr') and hasattr(self.session_mgr, 'bp'):

--- a/electrumx/server/rest_api.py
+++ b/electrumx/server/rest_api.py
@@ -482,6 +482,8 @@ async def _security_middleware(request: Request, call_next):
         '/swap', '/swap/', '/swaps', '/swaps/',
         '/royalties', '/royalties/',
         '/hashmark', '/hashmark/',
+        '/creators', '/creators/',
+        '/media', '/media/',
         '/containers', '/containers/', '/container', '/container/',
         '/users', '/users/',
         '/mempool', '/mempool/',
@@ -879,18 +881,125 @@ async def search_glyphs(
     q: str = Query(..., min_length=1, max_length=100, description="Search query (name or ticker)"),
     protocols: Optional[str] = Query(default=None, max_length=256, description="Comma-separated protocol IDs to filter"),
     limit: int = Query(default=50, le=200),
+    offset: int = Query(default=0, ge=0, description="Wildcard mode only: skip this many matches"),
+    wildcard: bool = Query(default=False, description="Force wildcard mode: treat q as *q* (substring)"),
 ):
-    """Search tokens by name or ticker."""
+    """Search tokens by name or ticker.
+
+    Exact by default. A `q` containing `*`, `?` or `[abc]` switches to wildcard mode, which matches
+    against **both** name and ticker, case-insensitively; `wildcard=true` forces that mode for
+    plain text (treating `q` as `*q*`). Pass `offset` to page wildcard results.
+
+    Exact search is an indexed lookup. Wildcard search is a bounded full scan — BY_NAME stores
+    `sha256(name)` and so cannot be seeked by prefix — and its response includes `scanned` and
+    `truncated` so you can tell a complete answer from a capped one.
+    """
     _ensure_glyph_index()
 
     try:
         protocol_list = None
         if protocols:
             protocol_list = [int(p.strip()) for p in protocols.split(',') if p.strip()]
+
+        if wildcard or any(ch in q for ch in '*?['):
+            result = _glyph_index.search_tokens_wildcard(
+                q, protocols=protocol_list, limit=limit, offset=offset,
+            )
+            return {"query": q, "mode": "wildcard", **result}
+
         result = _glyph_index.search_tokens(q, protocols=protocol_list, limit=limit)
-        return {"query": q, "results": result, "count": len(result)}
+        return {"query": q, "mode": "exact", "results": result, "count": len(result)}
     except Exception as e:
         raise _internal_error(e)
+
+
+_MEDIA_HASH_PATH = Path(..., min_length=64, max_length=64,
+                        description="Lowercase hex sha256 of the media bytes")
+
+
+@app.get("/media/{sha256}/glyphs", tags=["Ownership"])
+async def get_glyphs_by_media(
+    sha256: str = _MEDIA_HASH_PATH,
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor"),
+):
+    """Tokens whose media is byte-identical to this sha256.
+
+    Covers embedded media (sha256 of the raw bytes) and remote media (the committed `h`) in one
+    keyspace, so the same artwork is found however each token carries it. Rows are not
+    height-ordered — duplicate sets are small and each row carries `deploy_height`, so sort
+    client-side to badge the first mint.
+
+    A token detail response carries `media_sha256` and `media_duplicates`; use
+    `media_duplicates > 1` as the trigger to call this, rather than probing it per page view.
+    """
+    _ensure_glyph_index()
+
+    try:
+        media_hash = bytes.fromhex(sha256)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="media hash must be 64 lowercase hex chars")
+    if sha256 != sha256.lower() or len(media_hash) != 32:
+        raise HTTPException(status_code=400, detail="media hash must be 64 lowercase hex chars")
+
+    try:
+        return _glyph_index.get_tokens_by_media_hash(media_hash, limit=limit, cursor=cursor)
+    except Exception as e:
+        raise _internal_error(e, "get_glyphs_by_media")
+
+
+@app.get("/media/payload/{sha256}/glyphs", tags=["Ownership"])
+async def get_glyphs_by_payload(
+    sha256: str = _MEDIA_HASH_PATH,
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor"),
+):
+    """Tokens whose ENTIRE CBOR payload is byte-identical — a whole-record clone, not just
+    matching media.
+
+    No route-ordering hazard against /media/{sha256}/glyphs despite the shared prefix: that route
+    has one path segment where this has two, so they can never match the same URL.
+    """
+    _ensure_glyph_index()
+
+    try:
+        payload_hash = bytes.fromhex(sha256)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="payload hash must be 64 lowercase hex chars")
+    if len(payload_hash) != 32:
+        raise HTTPException(status_code=400, detail="payload hash must be 64 lowercase hex chars")
+
+    try:
+        return _glyph_index.get_tokens_by_payload_hash(payload_hash, limit=limit, cursor=cursor)
+    except Exception as e:
+        raise _internal_error(e, "get_glyphs_by_payload")
+
+
+@app.get("/creators/{ref}/works", tags=["Ownership"])
+async def get_creator_works(
+    ref: str = Path(..., min_length=1, max_length=128,
+                    description="Creator token ref: 72-hex or txid_vout"),
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor"),
+):
+    """Tokens attributed to a creator, from each token's metadata `by` field.
+
+    Attribution is **self-asserted**: `by` is written by whoever minted the token, and nothing
+    binds it to the referenced token's owner. Entries are claims of authorship, not proof — the
+    response repeats this as `attribution: "self-asserted"`.
+    """
+    _ensure_glyph_index()
+
+    try:
+        from electrumx.server.glyph_index import parse_ref_any
+        ref_bytes = parse_ref_any(ref)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid creator ref format")
+
+    try:
+        return _glyph_index.get_creator_works(ref_bytes, limit=limit, cursor=cursor)
+    except Exception as e:
+        raise _internal_error(e, "get_creator_works")
 
 
 @app.get("/glyphs/stats", tags=["Glyphs"])
@@ -1010,7 +1119,9 @@ async def get_container(ref: str = _REF_PATH):
             raise HTTPException(status_code=404, detail="Token not found")
         if not _glyph_index.has_meta_type('container', ref_bytes):
             raise HTTPException(status_code=404, detail="Token is not a container")
-        return _glyph_index._token_to_dict(token)
+        # Single-token detail: include the media-reuse extras (media_sha256 /
+        # media_duplicates), which cost a GMH prefix scan and so stay off for list pages.
+        return _glyph_index._token_to_dict(token, include_media_dupes=True)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
     except HTTPException:
@@ -1044,7 +1155,9 @@ async def get_glyph(ref: str = _REF_PATH):
         if not token:
             raise HTTPException(status_code=404, detail="Token not found")
 
-        return _glyph_index._token_to_dict(token)
+        # Single-token detail: include the media-reuse extras (media_sha256 /
+        # media_duplicates), which cost a GMH prefix scan and so stay off for list pages.
+        return _glyph_index._token_to_dict(token, include_media_dupes=True)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ref format")
     except HTTPException:

--- a/electrumx/server/rest_api.py
+++ b/electrumx/server/rest_api.py
@@ -62,6 +62,12 @@ from electrumx.lib.glyph import (
 )
 from electrumx.lib.hash import hash_to_hex_str
 from electrumx.server import metrics as _metrics
+from electrumx.server.hashmark_index import (
+    DEFAULT_LIMIT as HASHMARK_DEFAULT_LIMIT,
+    MAX_LIMIT as HASHMARK_MAX_LIMIT,
+    parse_digest_arg as parse_hashmark_digest,
+    resolve_algorithm as resolve_hashmark_algorithm,
+)
 from electrumx.server.rate_limiter import (
     DEFAULT_TRUSTED_PROXIES as _DEFAULT_TRUSTED_PROXIES,
     IPRateLimiter as _IPRateLimiter,
@@ -433,6 +439,9 @@ async def _security_middleware(request: Request, call_next):
         '/wave', '/wave/',
         '/swap', '/swap/', '/swaps', '/swaps/',
         '/royalties', '/royalties/',
+        '/hashmark', '/hashmark/',
+        '/containers', '/containers/', '/container', '/container/',
+        '/users', '/users/',
         '/mempool', '/mempool/',
         '/addresses', '/addresses/',
         '/docs', '/openapi',
@@ -471,6 +480,7 @@ _glyph_index = None
 _wave_index = None
 _swap_index = None
 _royalty_index = None
+_hashmark_index = None
 _analytics_index = None
 _dmint_contracts = None
 _mempool = None
@@ -480,16 +490,17 @@ _start_time = time.time()
 
 
 def set_indexer(glyph_index, db, daemon, wave_index=None, swap_index=None,
-                royalty_index=None, analytics_index=None, dmint_contracts=None,
-                mempool=None):
+                royalty_index=None, hashmark_index=None, analytics_index=None,
+                dmint_contracts=None, mempool=None):
     """Set the indexer references from the main server."""
-    global _glyph_index, _db, _daemon, _wave_index, _swap_index, _royalty_index, _analytics_index, _dmint_contracts, _mempool
+    global _glyph_index, _db, _daemon, _wave_index, _swap_index, _royalty_index, _hashmark_index, _analytics_index, _dmint_contracts, _mempool
     _glyph_index = glyph_index
     _db = db
     _daemon = daemon
     _wave_index = wave_index
     _swap_index = swap_index
     _royalty_index = royalty_index
+    _hashmark_index = hashmark_index
     _analytics_index = analytics_index
     _dmint_contracts = dmint_contracts
     _mempool = mempool
@@ -2116,6 +2127,60 @@ async def get_royalty_stats():
         }
     except Exception as e:
         raise _internal_error(e)
+
+
+# =============================================================================
+# HASHMARK (Digest Lookup)
+# =============================================================================
+
+def _ensure_hashmark():
+    if not _hashmark_index:
+        raise HTTPException(status_code=503, detail="HashMark index not available")
+
+
+# Declared before /hashmark/{digest} so "stats" is routed here rather than parsed as a digest.
+@app.get("/hashmark/stats", tags=["HashMark"])
+async def get_hashmark_stats():
+    """HashMark index status, including historic-backfill progress.
+
+    `backfill_complete` tells a client whether an empty lookup means "never marked" or
+    "not scanned back that far yet"."""
+    _ensure_hashmark()
+    try:
+        return _hashmark_index.stats()
+    except Exception as e:
+        raise _internal_error(e, "hashmark_stats")
+
+
+@app.get("/hashmark/{digest}", tags=["HashMark"])
+async def hashmark_lookup(
+    digest: str = Path(..., min_length=16, max_length=128,
+                       description="Full lowercase hex digest (sha256 -> 64 chars)"),
+    algorithm: str = Query(default="sha256", description="Algorithm name ('sha256') or id ('1')"),
+    limit: int = Query(default=HASHMARK_DEFAULT_LIMIT, ge=1, le=HASHMARK_MAX_LIMIT),
+):
+    """Confirmed HashMark records for one digest, oldest first.
+
+    Returns `[]` when the digest was never marked — a normal answer, not a 404.  A hit is a search
+    hint: the caller is expected to re-fetch the transaction and re-decode the output itself.
+    """
+    _ensure_hashmark()
+
+    alg_id = resolve_hashmark_algorithm(algorithm)
+    if alg_id is None:
+        raise HTTPException(status_code=400, detail=f"Unknown algorithm: {algorithm}")
+    digest_bytes = parse_hashmark_digest(digest, alg_id)
+    if digest_bytes is None:
+        # Strict full-length match only: prefix search would let a caller enumerate the index.
+        raise HTTPException(
+            status_code=400,
+            detail="digest must be the full lowercase hex digest for this algorithm",
+        )
+
+    try:
+        return _hashmark_index.lookup(digest_bytes, alg_id, limit)
+    except Exception as e:
+        raise _internal_error(e, "hashmark_lookup")
 
 
 # =============================================================================

--- a/electrumx/server/rest_api.py
+++ b/electrumx/server/rest_api.py
@@ -864,7 +864,7 @@ def get_glyph_stats():
 
 @app.get("/glyphs/by-type/{type_id}", tags=["Glyphs"])
 async def get_glyphs_by_type(
-    type_id: int = Path(..., ge=0, le=7, description="Token type ID (1=FT, 2=NFT, 3=DAT, 4=DMINT, 5=WAVE, 6=Container, 7=Authority)"),
+    type_id: int = Path(..., ge=0, le=7, description="Token type ID (1=FT, 2=NFT, 3=DAT, 4=DMINT, 5=WAVE, 7=Authority). Note: use GET /containers for container tokens and GET /users for user-profile tokens."),
     limit: int = Query(default=100, le=500),
     cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor from previous response next_cursor"),
     order: str = Query(default="ref", pattern="^(ref|recent)$", description="'ref' (legacy hash order) or 'recent' (newest-deployed first). Cursors are order-specific."),
@@ -920,6 +920,73 @@ async def list_encrypted_tokens(
             limit=limit, cursor=cursor, timelocked_only=timelocked_only
         )
         return {**result, "timelocked_only": timelocked_only}
+    except Exception as e:
+        raise _internal_error(e)
+
+
+@app.get("/containers", tags=["Containers"])
+async def list_containers(
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor from previous response next_cursor"),
+):
+    """List all container tokens."""
+    _ensure_glyph_index()
+
+    try:
+        return _glyph_index.get_tokens_by_meta_type('container', limit=limit, cursor=cursor)
+    except Exception as e:
+        raise _internal_error(e)
+
+
+@app.get("/containers/{ref}/members", tags=["Containers"])
+async def get_container_members(
+    ref: str = _REF_PATH,
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor from previous response next_cursor"),
+):
+    """Get all member tokens belonging to a container."""
+    _ensure_glyph_index()
+
+    try:
+        ref_bytes = _resolve_ref(ref)
+        return _glyph_index.get_container_members(ref_bytes, limit=limit, cursor=cursor)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ref format")
+    except Exception as e:
+        raise _internal_error(e)
+
+
+@app.get("/containers/{ref}", tags=["Containers"])
+async def get_container(ref: str = _REF_PATH):
+    """Get a container token by reference."""
+    _ensure_glyph_index()
+
+    try:
+        ref_bytes = _resolve_ref(ref)
+        token = _glyph_index.get_token(ref_bytes)
+        if not token:
+            raise HTTPException(status_code=404, detail="Token not found")
+        if not _glyph_index.has_meta_type('container', ref_bytes):
+            raise HTTPException(status_code=404, detail="Token is not a container")
+        return _glyph_index._token_to_dict(token)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ref format")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise _internal_error(e)
+
+
+@app.get("/users", tags=["Users"])
+async def list_users(
+    limit: int = Query(default=100, le=500),
+    cursor: Optional[str] = Query(default=None, description="Opaque pagination cursor from previous response next_cursor"),
+):
+    """List all user-profile tokens (metadata type == 'user')."""
+    _ensure_glyph_index()
+
+    try:
+        return _glyph_index.get_tokens_by_meta_type('user', limit=limit, cursor=cursor)
     except Exception as e:
         raise _internal_error(e)
 

--- a/electrumx/server/rest_api.py
+++ b/electrumx/server/rest_api.py
@@ -332,6 +332,42 @@ _TRUSTED_PROXIES = _IPRateLimiter._parse_networks(
     os.getenv('TRUSTED_PROXIES', '').strip() or _DEFAULT_TRUSTED_PROXIES
 )
 
+# Rate-limit exemption allowlist. Comma-separated CIDRs/IPs, or the shorthand
+# token `private` for loopback + RFC1918 + link-local + IPv6 ULA/loopback —
+# i.e. "don't throttle callers on my own network".
+#
+# Default empty => every caller is limited, preserving current behaviour.
+#
+# Matched against the RESOLVED client IP (see _get_client_ip), not the raw
+# socket peer, so that behind a reverse proxy the real client is what counts —
+# exempting on the socket peer would exempt EVERY caller, since the peer is then
+# always the proxy. The corollary is that with TRUST_PROXY=1 this inherits the
+# forwarded chain's trust model: the proxy MUST overwrite (not append to) an
+# inbound X-Forwarded-For, or a remote caller could claim an internal IP and
+# exempt itself. With TRUST_PROXY=0 the resolved IP is the socket peer and
+# cannot be spoofed.
+_PRIVATE_NETWORK_SPEC = ('127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,'
+                         '169.254.0.0/16,::1/128,fc00::/7,fe80::/10')
+
+
+def _parse_rate_exempt(spec: str):
+    """Parse REST_RATE_LIMIT_EXEMPT, expanding the `private` shorthand."""
+    if not spec:
+        return []
+    tokens = []
+    for tok in spec.split(','):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if tok.lower() == 'private':
+            tokens.append(_PRIVATE_NETWORK_SPEC)
+        else:
+            tokens.append(tok)
+    return _IPRateLimiter._parse_networks(','.join(tokens))
+
+
+_RATE_LIMIT_EXEMPT = _parse_rate_exempt(os.getenv('REST_RATE_LIMIT_EXEMPT', '').strip())
+
 
 def _get_client_ip(request: Request) -> str:
     """R8 + XFF-spoof hardening: resolve the real client IP, honouring
@@ -367,6 +403,12 @@ def _rate_limit(request: Request):
         return
 
     client_host = _get_client_ip(request)  # R8
+
+    # Exempt allowlisted callers before any bucket is created, so internal
+    # traffic neither throttles nor occupies memory in _rate_buckets.
+    if _RATE_LIMIT_EXEMPT and _peer_in_networks(client_host, _RATE_LIMIT_EXEMPT):
+        return
+
     now = time.time()
 
     # Purge stale buckets: every 1000 requests OR every 60 seconds (R17)
@@ -573,7 +615,7 @@ async def health_db():
         return {
             "status": "connected",
             "height": height,
-            "db_engine": getattr(_db, 'db_engine', 'unknown'),
+            "db_engine": getattr(getattr(_db, 'env', None), 'db_engine', 'unknown'),
         }
     except Exception as e:
         _logger.error("health/db DB error: %s", e, exc_info=True)
@@ -590,7 +632,7 @@ async def get_status():
 
     if _db:
         status["sync_height"] = _db.db_height
-        status["db_engine"] = getattr(_db, 'db_engine', 'unknown')
+        status["db_engine"] = getattr(getattr(_db, 'env', None), 'db_engine', 'unknown')
 
     if _glyph_index:
         status["glyph_indexing"] = True

--- a/tests/server/test_parser_halt_guard.py
+++ b/tests/server/test_parser_halt_guard.py
@@ -266,6 +266,7 @@ def _make_bp():
     bp.predict_index = None
     bp.royalty_index = None
     bp.analytics_index = None
+    bp.hashmark_index = None
     bp.subscriptions = None
     bp.dmint_contracts = None
     return bp

--- a/tests/server/test_rest_api.py
+++ b/tests/server/test_rest_api.py
@@ -117,7 +117,10 @@ def mock_dmint_contracts():
 def mock_db():
     db = Mock()
     db.db_height = 100000
-    db.db_engine = 'rocksdb'
+    # On the real DB this lives on env (see db.py, `self.env.db_engine`); the
+    # mock previously set it directly, which is why /health/db reporting
+    # 'unknown' went unnoticed.
+    db.env.db_engine = 'rocksdb'
     return db
 
 
@@ -928,6 +931,60 @@ class TestProxyTrustedPeerGate:
         # The bucket was created under the attacker's real peer, NOT the victim.
         assert '198.51.100.99' in rest_api._rate_buckets
         assert '203.0.113.7' not in rest_api._rate_buckets
+
+    def test_exempt_allowlist_defaults_to_empty(self, monkeypatch):
+        """No REST_RATE_LIMIT_EXEMPT => everyone is limited, as before."""
+        from electrumx.server import rest_api
+        monkeypatch.setattr(rest_api, '_RATE_LIMIT_EXEMPT', [])
+        monkeypatch.setattr(rest_api, '_rate_buckets', {})
+        monkeypatch.setenv('REST_RATE_LIMIT_PER_MIN', '600')
+
+        rest_api._rate_limit(self._make_request({}, client_host='10.1.2.3'))
+        assert '10.1.2.3' in rest_api._rate_buckets
+
+    def test_exempt_internal_ip_creates_no_bucket(self, monkeypatch):
+        """An allowlisted caller returns early: not throttled, and no bucket
+        retained (so internal polling cannot grow _rate_buckets)."""
+        from electrumx.server import rest_api
+        monkeypatch.setattr(rest_api, '_RATE_LIMIT_EXEMPT',
+                            rest_api._parse_rate_exempt('private'))
+        monkeypatch.setattr(rest_api, '_rate_buckets', {})
+        monkeypatch.setenv('REST_RATE_LIMIT_PER_MIN', '600')
+
+        for host in ('10.1.2.3', '192.168.0.5', '127.0.0.1', '172.20.0.9'):
+            rest_api._rate_limit(self._make_request({}, client_host=host))
+        assert rest_api._rate_buckets == {}
+
+        # A public caller is still limited and still gets a bucket.
+        rest_api._rate_limit(self._make_request({}, client_host='203.0.113.7'))
+        assert '203.0.113.7' in rest_api._rate_buckets
+
+    def test_exempt_matches_resolved_client_not_proxy_peer(self, monkeypatch):
+        """Behind a trusted proxy the socket peer is the proxy (private), so
+        exemption must key on the RESOLVED client — otherwise every caller
+        through the proxy would be exempt."""
+        from electrumx.server import rest_api
+        monkeypatch.setattr(rest_api, '_TRUST_PROXY', True)
+        monkeypatch.setattr(rest_api, '_TRUST_PROXY_HOPS', 1)
+        monkeypatch.setattr(
+            rest_api, '_TRUSTED_PROXIES',
+            _IPRateLimiter._parse_networks('172.18.0.0/16'),
+        )
+        monkeypatch.setattr(rest_api, '_RATE_LIMIT_EXEMPT',
+                            rest_api._parse_rate_exempt('private'))
+        monkeypatch.setattr(rest_api, '_rate_buckets', {})
+        monkeypatch.setenv('REST_RATE_LIMIT_PER_MIN', '600')
+
+        # Public client arriving via the private-IP proxy: still limited.
+        rest_api._rate_limit(self._make_request(
+            {'x-forwarded-for': '203.0.113.7'}, client_host='172.18.0.2'))
+        assert '203.0.113.7' in rest_api._rate_buckets
+
+    def test_exempt_ignores_unparseable_tokens(self, monkeypatch):
+        from electrumx.server import rest_api
+        nets = rest_api._parse_rate_exempt('garbage,,10.0.0.0/8')
+        assert rest_api._peer_in_networks('10.1.2.3', nets)
+        assert not rest_api._peer_in_networks('203.0.113.7', nets)
 
 
 # ===========================================================================

--- a/tests/test_glyph_creator_and_wildcard.py
+++ b/tests/test_glyph_creator_and_wildcard.py
@@ -1,0 +1,453 @@
+"""
+Tests for the creator attribution index (GA / v7) and wildcard name+ticker search.
+
+Both were added because no data source could answer their question before: `by` was never read
+anywhere in the tree, and BY_NAME stores sha256(name) so no partial match was possible.
+
+GT rows are CBOR, and cbor2 is not always present in a bare checkout, so the token codec is stubbed
+where needed. What stays under test is the code these features added: the GA key derivation (live
+path and v7 backfill deriving identical keys), and the wildcard matcher's semantics and ordering.
+
+Run: PYTHONPATH=. python3 -m pytest tests/test_glyph_creator_and_wildcard.py
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import electrumx.server.glyph_index as gi  # noqa: E402
+from electrumx.server.glyph_index import GlyphDBKeys, GlyphIndex  # noqa: E402
+
+CREATOR = bytes([0xC0]) * 36
+OTHER_CREATOR = bytes([0xC1]) * 36
+WORK_A = bytes([0xA1]) * 36
+WORK_B = bytes([0xB2]) * 36
+
+
+class _Batch:
+    def __init__(self, store):
+        self.store = store
+
+    def put(self, key, value):
+        self.store[key] = value
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _StubUtxoDB:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def write_batch(self):
+        return _Batch(self.store)
+
+    def iterator(self, prefix=b'', seek=None, reverse=False):
+        keys = sorted(k for k in self.store if k.startswith(prefix))
+        if seek is not None:
+            keys = [k for k in keys if k >= seek]
+        for key in keys:
+            yield key, self.store[key]
+
+
+class _Logger:
+    def info(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+    def exception(self, *a, **k):
+        pass
+
+
+class _TokenStub:
+    """Stands in for GlyphTokenInfo for the CBOR-free paths."""
+
+    MARKER = b'MH:'
+
+    def __init__(self, name=None, ticker=None, protocols=None, metadata_hash=b''):
+        self.name = name
+        self.ticker = ticker
+        self.protocols = protocols or [2]
+        self.metadata_hash = metadata_hash
+
+    @classmethod
+    def from_bytes(cls, data):
+        if not data.startswith(cls.MARKER):
+            raise ValueError('not a token row')
+        meta_hash = data[len(cls.MARKER):]
+        return SimpleNamespace(metadata_hash=meta_hash)
+
+
+def _bare_index():
+    idx = object.__new__(GlyphIndex)
+    idx.db = SimpleNamespace(utxo_db=_StubUtxoDB(), db_height=500000)
+    idx.logger = _Logger()
+    idx.metadata_cache = {}
+    return idx
+
+
+# --------------------------------------------------------------------------- v7 backfill (GA)
+
+def _migration_index(rows, metadata_by_hash):
+    idx = _bare_index()
+    for ref, meta_hash in rows:
+        idx.db.utxo_db.store[GlyphDBKeys.TOKEN + ref] = _TokenStub.MARKER + meta_hash
+    idx.get_metadata = lambda h: metadata_by_hash.get(h)
+    return idx
+
+
+def _run_migration(idx, name='_migrate_6_to_7'):
+    saved = gi.GlyphTokenInfo.from_bytes
+    gi.GlyphTokenInfo.from_bytes = _TokenStub.from_bytes
+    try:
+        return getattr(idx, name)()
+    finally:
+        gi.GlyphTokenInfo.from_bytes = saved
+
+
+def _ga_keys(idx):
+    return sorted(k for k in idx.db.utxo_db.store if k.startswith(GlyphDBKeys.BY_CREATOR))
+
+
+def test_backfill_derives_the_live_ga_key():
+    idx = _migration_index([(WORK_A, b'h1')], {b'h1': {'by': [CREATOR]}})
+    assert _run_migration(idx) == 1
+    assert _ga_keys(idx) == [GlyphDBKeys.BY_CREATOR + CREATOR + WORK_A]
+
+
+def test_backfill_unwraps_cbor_tags():
+    tagged = SimpleNamespace(value=CREATOR)
+    idx = _migration_index([(WORK_A, b'h1')], {b'h1': {'by': [tagged]}})
+    assert _run_migration(idx) == 1
+    assert _ga_keys(idx) == [GlyphDBKeys.BY_CREATOR + CREATOR + WORK_A]
+
+
+def test_backfill_ignores_malformed_by_fields():
+    idx = _migration_index(
+        [(WORK_A, b'h1'), (WORK_B, b'h2')],
+        {b'h1': {'by': [b'\x01' * 35]},   # wrong length
+         b'h2': {'by': 'not-a-list'}},    # wrong type
+    )
+    assert _run_migration(idx) == 0
+    assert _ga_keys(idx) == []
+
+
+def test_backfill_is_idempotent():
+    idx = _migration_index([(WORK_A, b'h1')], {b'h1': {'by': [CREATOR]}})
+    _run_migration(idx)
+    before = dict(idx.db.utxo_db.store)
+    _run_migration(idx)
+    assert idx.db.utxo_db.store == before
+
+
+def test_ga_prefix_introduces_no_aliasing():
+    # 'GBY' (the originally proposed prefix) would sit under BALANCE's 'GB', whose scans seek on
+    # GB + hashX(11). Assert the chosen prefix collides with nothing.
+    prefixes = [v for k, v in vars(GlyphDBKeys).items() if isinstance(v, bytes)]
+    ga = GlyphDBKeys.BY_CREATOR
+    for other in prefixes:
+        if other == ga:
+            continue
+        assert not ga.startswith(other), f'{ga!r} sits under {other!r}'
+        assert not other.startswith(ga), f'{other!r} sits under {ga!r}'
+
+
+def test_v7_migrator_is_registered():
+    # Asserts the v7 STEP, not the global schema version — that moves every time a new index is
+    # added, and test_migration_chain_is_registered_for_every_step already checks the whole chain
+    # against CURRENT_SCHEMA_VERSION.
+    src = open(os.path.join(os.path.dirname(__file__), '..', 'electrumx', 'server',
+                            'glyph_index.py'), encoding='utf-8').read()
+    assert '6: self._migrate_6_to_7' in src
+    assert 'def _migrate_6_to_7' in src
+
+
+# --------------------------------------------------------------------------- creator queries
+
+def test_get_creator_works_returns_only_that_creator():
+    idx = _bare_index()
+    store = idx.db.utxo_db.store
+    store[GlyphDBKeys.BY_CREATOR + CREATOR + WORK_A] = b''
+    store[GlyphDBKeys.BY_CREATOR + CREATOR + WORK_B] = b''
+    store[GlyphDBKeys.BY_CREATOR + OTHER_CREATOR + WORK_A] = b''
+    idx.get_token = lambda ref: _TokenStub(name='n')
+    idx._token_to_dict = lambda t, **k: {'ref': 'x'}
+    idx._decode_cursor = lambda c: None
+    idx._encode_cursor = lambda k: 'cur'
+
+    out = idx.get_creator_works(CREATOR, limit=100)
+    assert len(out['tokens']) == 2
+    assert out['attribution'] == 'self-asserted', 'callers must be told this is a claim'
+    assert out['next_cursor'] is None
+    assert idx.count_creator_works(CREATOR) == 2
+    assert idx.count_creator_works(OTHER_CREATOR) == 1
+
+
+def test_get_creator_works_pages_with_a_cursor():
+    idx = _bare_index()
+    for i in range(5):
+        idx.db.utxo_db.store[GlyphDBKeys.BY_CREATOR + CREATOR + bytes([i]) * 36] = b''
+    idx.get_token = lambda ref: _TokenStub(name='n')
+    idx._token_to_dict = lambda t, **k: {'ref': 'x'}
+    idx._decode_cursor = lambda c: None
+    idx._encode_cursor = lambda k: 'cur'
+
+    out = idx.get_creator_works(CREATOR, limit=2)
+    assert len(out['tokens']) == 2
+    assert out['next_cursor'] == 'cur'
+
+
+# --------------------------------------------------------------------------- wildcard search
+
+def _search_index(tokens):
+    """tokens: list of (ref, name, ticker, protocols)."""
+    idx = _bare_index()
+    store = idx.db.utxo_db.store
+    lookup = {}
+    for ref, name, ticker, protos in tokens:
+        store[GlyphDBKeys.TOKEN + ref] = b'TOK:' + ref
+        lookup[ref] = _TokenStub(name=name, ticker=ticker, protocols=protos)
+    idx._token_to_dict = lambda t, **k: {'name': t.name, 'ticker': t.ticker}
+    return idx, lookup
+
+
+def _run_search(idx, lookup, *args, **kwargs):
+    saved = gi.GlyphTokenInfo.from_bytes
+    gi.GlyphTokenInfo.from_bytes = lambda data: lookup[data[4:]]
+    try:
+        return idx.search_tokens_wildcard(*args, **kwargs)
+    finally:
+        gi.GlyphTokenInfo.from_bytes = saved
+
+
+TOKENS = [
+    (bytes([1]) * 36, 'gatorcoin', 'GATOR', [1]),
+    (bytes([2]) * 36, 'gatorade', 'GADE', [1]),
+    (bytes([3]) * 36, 'alligator', 'ALLI', [2]),
+    (bytes([4]) * 36, 'photonlink', 'PHOTON', [2]),
+    (bytes([5]) * 36, None, 'GATORX', [2]),
+]
+
+
+def test_bare_text_is_a_substring_search():
+    idx, lookup = _search_index(TOKENS)
+    out = _run_search(idx, lookup, 'gator')
+    names = [t['name'] for t in out['tokens']]
+    # Includes the infix match, which no ordered index over hashed names could ever return.
+    assert 'alligator' in names
+    assert 'gatorcoin' in names and 'gatorade' in names
+    assert out['pattern'] == '*gator*'
+
+
+def test_prefix_wildcard():
+    idx, lookup = _search_index(TOKENS)
+    out = _run_search(idx, lookup, 'gator*')
+    names = [t['name'] for t in out['tokens']]
+    assert 'gatorcoin' in names and 'gatorade' in names
+    assert 'alligator' not in names, 'gator* must not match an infix'
+
+
+def test_ticker_is_searched_too():
+    idx, lookup = _search_index(TOKENS)
+    # This token has NO name; it can only be found via its ticker.
+    out = _run_search(idx, lookup, 'gatorx')
+    assert [t['ticker'] for t in out['tokens']] == ['GATORX']
+
+
+def test_matching_is_case_insensitive_on_both_fields():
+    idx, lookup = _search_index(TOKENS)
+    assert _run_search(idx, lookup, 'GATORCOIN')['count'] == 1
+    assert _run_search(idx, lookup, 'photon')['count'] == 1
+
+
+def test_question_mark_and_class_patterns():
+    idx, lookup = _search_index(TOKENS)
+    # '?' is exactly one char, and the pattern is anchored: 8 chars cannot match a 9-char name.
+    assert _run_search(idx, lookup, 'gator?in')['count'] == 0
+    # ...but 9 chars can, with '?' standing in for the 'c'.
+    assert _run_search(idx, lookup, 'gator?oin')['count'] == 1
+    assert _run_search(idx, lookup, 'gatorcoi?')['count'] == 1
+    assert _run_search(idx, lookup, '[ag]lligator')['count'] == 1
+
+
+def test_protocol_filter_applies():
+    idx, lookup = _search_index(TOKENS)
+    out = _run_search(idx, lookup, '*gator*', protocols=[1])
+    names = sorted(t['name'] for t in out['tokens'])
+    assert names == ['gatorade', 'gatorcoin'], 'alligator is protocol 2'
+
+
+def test_results_are_alphabetical_and_page_stably():
+    idx, lookup = _search_index(TOKENS)
+    full = _run_search(idx, lookup, '*a*', limit=100)
+    # Ordering is case-insensitive (the sort key is the lowercased name, falling back to ticker),
+    # so compare on the same footing rather than raw case.
+    ordered = [(t['name'] or t['ticker']).lower() for t in full['tokens']]
+    assert ordered == sorted(ordered), 'ordering must not depend on ref order'
+
+    page1 = _run_search(idx, lookup, '*a*', limit=2, offset=0)
+    page2 = _run_search(idx, lookup, '*a*', limit=2, offset=2)
+    seen = [t['name'] for t in page1['tokens']] + [t['name'] for t in page2['tokens']]
+    assert len(seen) == len(set(seen)), 'pages must not overlap'
+    assert page1['has_more'] is True
+
+
+def test_empty_pattern_returns_nothing():
+    idx, lookup = _search_index(TOKENS)
+    out = _run_search(idx, lookup, '   ')
+    assert out['count'] == 0 and out['tokens'] == []
+
+
+def test_scan_cap_is_reported():
+    idx, lookup = _search_index(TOKENS)
+    saved = gi.MAX_WILDCARD_SCAN
+    gi.MAX_WILDCARD_SCAN = 2
+    try:
+        out = _run_search(idx, lookup, '*gator*')
+        assert out['truncated'] is True, 'a capped answer must say so'
+        assert out['scanned'] == 2
+    finally:
+        gi.MAX_WILDCARD_SCAN = saved
+
+
+def test_untruncated_scan_reports_false():
+    idx, lookup = _search_index(TOKENS)
+    out = _run_search(idx, lookup, '*gator*')
+    assert out['truncated'] is False
+    assert out['scanned'] == len(TOKENS)
+
+
+if __name__ == '__main__':
+    import pytest
+    sys.exit(pytest.main([__file__, '-v']))
+
+
+# --------------------------------------------------------------------------- media hash (v8 / GMH)
+
+from electrumx.lib.hash import sha256 as _sha256  # noqa: E402
+
+MEDIA = b'\x89PNG\r\n\x1a\n' + b'pretend-image-bytes' * 4
+MEDIA_HASH = _sha256(MEDIA)
+
+
+def test_embed_and_remote_forms_of_one_artwork_collide():
+    """The whole point of a single-sha256 keyspace: an embedded copy and a remote copy of the same
+    file must land on the SAME key, so re-uploads are detectable across both carriage forms."""
+    from electrumx.server.glyph_index import media_hashes_from_metadata
+
+    embedded = media_hashes_from_metadata({'main': {'t': 'image/png', 'b': MEDIA}})
+    remote = media_hashes_from_metadata({'remote': {'t': 'image/png', 'u': 'ipfs://x',
+                                                    'h': MEDIA_HASH}})
+    assert embedded == {MEDIA_HASH}
+    assert remote == {MEDIA_HASH}
+    assert embedded == remote
+
+
+def test_media_hash_is_single_not_double_sha256():
+    from electrumx.server.glyph_index import media_hashes_from_metadata
+    got = media_hashes_from_metadata({'em': {'b': MEDIA}})
+    assert got == {_sha256(MEDIA)}
+    assert got != {_sha256(_sha256(MEDIA))}, 'double-hashing would break remote-h collision'
+
+
+def test_cbor_tag_hex_and_bytes_payloads_agree():
+    from electrumx.server.glyph_index import media_hashes_from_metadata, unwrap_cbor_bytes
+    assert unwrap_cbor_bytes(MEDIA) == MEDIA
+    assert unwrap_cbor_bytes(SimpleNamespace(value=MEDIA)) == MEDIA
+    assert unwrap_cbor_bytes(SimpleNamespace(value=MEDIA.hex())) == MEDIA
+    assert unwrap_cbor_bytes(SimpleNamespace(value='not-hex')) is None
+    assert unwrap_cbor_bytes(None) is None
+    # All three spellings of the same bytes must produce one key.
+    for payload in (MEDIA, SimpleNamespace(value=MEDIA), SimpleNamespace(value=MEDIA.hex())):
+        assert media_hashes_from_metadata({'main': {'b': payload}}) == {MEDIA_HASH}
+
+
+def test_token_with_both_embed_and_remote_yields_both_hashes():
+    """The token-field extraction is an elif, so only one wins there; the index must not inherit
+    that, or a token carrying both would be findable by only one hash."""
+    from electrumx.server.glyph_index import media_hashes_from_metadata
+    other = _sha256(b'a different file')
+    got = media_hashes_from_metadata({
+        'embed': {'b': MEDIA},
+        'remote': {'u': 'ipfs://y', 'h': other},
+    })
+    assert got == {MEDIA_HASH, other}
+
+
+def test_no_media_yields_no_keys():
+    from electrumx.server.glyph_index import media_hashes_from_metadata
+    assert media_hashes_from_metadata({}) == set()
+    assert media_hashes_from_metadata({'main': {'t': 'image/png'}}) == set()   # no bytes
+    assert media_hashes_from_metadata({'main': 'not-a-dict'}) == set()
+    assert media_hashes_from_metadata({'remote': {'h': b'\x01' * 31}}) == set()  # wrong length
+    assert media_hashes_from_metadata(None) == set()
+
+
+def test_v8_backfill_writes_gmh_and_gdh():
+    idx = _migration_index([(WORK_A, b'h1')], {b'h1': {'main': {'b': MEDIA}}})
+    assert _run_migration(idx, '_migrate_7_to_8') == 2   # one GMH + one GDH
+    store = idx.db.utxo_db.store
+    assert GlyphDBKeys.MEDIA_HASH + MEDIA_HASH + WORK_A in store
+    assert GlyphDBKeys.PAYLOAD_HASH + b'h1' + WORK_A in store
+
+
+def test_v8_backfill_is_idempotent():
+    idx = _migration_index([(WORK_A, b'h1')], {b'h1': {'main': {'b': MEDIA}}})
+    _run_migration(idx, '_migrate_7_to_8')
+    before = dict(idx.db.utxo_db.store)
+    _run_migration(idx, '_migrate_7_to_8')
+    assert idx.db.utxo_db.store == before
+
+
+def test_media_lookup_and_bounded_count():
+    idx = _bare_index()
+    store = idx.db.utxo_db.store
+    for i in range(3):
+        store[GlyphDBKeys.MEDIA_HASH + MEDIA_HASH + bytes([i]) * 36] = b''
+    store[GlyphDBKeys.MEDIA_HASH + _sha256(b'other') + WORK_B] = b''
+    idx.get_token = lambda ref: _TokenStub(name='n')
+    idx._token_to_dict = lambda t, **k: {'ref': 'x'}
+    idx._decode_cursor = lambda c: None
+    idx._encode_cursor = lambda k: 'cur'
+
+    out = idx.get_tokens_by_media_hash(MEDIA_HASH, limit=100)
+    assert len(out['tokens']) == 3
+    # .hex(), not reversed txid-style hex, or no client-computed sha256 would ever match.
+    assert out['media_sha256'] == MEDIA_HASH.hex()
+    assert idx.count_tokens_by_media_hash(MEDIA_HASH) == 3
+
+
+def test_duplicate_count_is_capped():
+    idx = _bare_index()
+    for i in range(80):
+        idx.db.utxo_db.store[GlyphDBKeys.MEDIA_HASH + MEDIA_HASH + bytes([i]) * 36] = b''
+    n = idx.count_tokens_by_media_hash(MEDIA_HASH)
+    assert n == 51, 'must stop at the cap rather than scanning all 80'
+
+
+def test_media_prefixes_do_not_alias_a_scanned_prefix():
+    """GMH sits under METADATA's 'GM', which is only ever exact-get. GDH deliberately avoids 'GP'
+    (BY_PROTO), which IS prefix-scanned as GP + proto(1)."""
+    assert GlyphDBKeys.MEDIA_HASH == b'GMH'
+    assert GlyphDBKeys.PAYLOAD_HASH == b'GDH'
+    assert not GlyphDBKeys.PAYLOAD_HASH.startswith(GlyphDBKeys.BY_PROTO)
+
+
+def test_schema_v8_registered():
+    from electrumx.server.glyph_index import CURRENT_SCHEMA_VERSION
+    assert CURRENT_SCHEMA_VERSION == 8
+    src = open(os.path.join(os.path.dirname(__file__), '..', 'electrumx', 'server',
+                            'glyph_index.py'), encoding='utf-8').read()
+    assert '7: self._migrate_7_to_8' in src

--- a/tests/test_glyph_schema_migrations.py
+++ b/tests/test_glyph_schema_migrations.py
@@ -221,12 +221,22 @@ def test_page_walk_resumes_strictly_after_the_last_key():
 
 
 def test_migration_chain_is_registered_for_every_step():
-    # A gap here is what produced "version 4 < 6 has no in-place migration" on deploy.
+    """Every version from 3 up to CURRENT must have an in-place migrator.
+
+    A gap here is what produced "version 4 < 6 has no in-place migration" on deploy. Derived from
+    CURRENT_SCHEMA_VERSION rather than hard-coded, so bumping the schema without adding a migrator
+    fails this test instead of silently shipping a hard-fail to production.
+    """
+    from electrumx.server.glyph_index import CURRENT_SCHEMA_VERSION
+
     src = open(os.path.join(os.path.dirname(__file__), '..', 'electrumx', 'server',
                             'glyph_index.py'), encoding='utf-8').read()
-    for step in ('3: self._migrate_3_to_4', '4: self._migrate_4_to_5', '5: self._migrate_5_to_6'):
-        assert step in src, f'missing migration step: {step}'
-    assert 'CURRENT_SCHEMA_VERSION = 6' in src
+    for v in range(3, CURRENT_SCHEMA_VERSION):
+        step = f'{v}: self._migrate_{v}_to_{v + 1}'
+        assert step in src, (
+            f'schema v{v} -> v{v + 1} has no registered in-place migrator; '
+            f'a node at v{v} would refuse to start')
+        assert f'def _migrate_{v}_to_{v + 1}' in src, f'missing _migrate_{v}_to_{v + 1} definition'
 
 
 if __name__ == '__main__':

--- a/tests/test_glyph_schema_migrations.py
+++ b/tests/test_glyph_schema_migrations.py
@@ -1,0 +1,234 @@
+"""
+Tests for the in-place Glyph schema migrations v4->v5 (GCM) and v5->v6 (GMT).
+
+The property that matters: a migrator must derive keys BYTE-IDENTICAL to the live write path in
+GlyphIndex.process_tx. A divergence would silently produce rows that live writes never match and
+queries never find — an index that looks populated but answers wrong.
+
+GT/GM rows are CBOR-encoded, and cbor2 is not always present in a bare checkout, so the CBOR layer
+is stubbed here. What remains under test is exactly the code these migrations added: the page/seek
+walk, the metadata gating, and the key derivation.
+
+Run: PYTHONPATH=. python3 -m pytest tests/test_glyph_schema_migrations.py
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import electrumx.server.glyph_index as gi  # noqa: E402
+from electrumx.server.glyph_index import GlyphDBKeys, GlyphIndex  # noqa: E402
+from electrumx.lib.hash import sha256  # noqa: E402
+
+REF_A = bytes([0xA1]) * 36
+REF_B = bytes([0xB2]) * 36
+REF_C = bytes([0xC3]) * 36
+CONTAINER = bytes([0xDD]) * 36
+
+
+class _Batch:
+    def __init__(self, store):
+        self.store = store
+
+    def put(self, key, value):
+        self.store[key] = value
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _StubUtxoDB:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def write_batch(self):
+        return _Batch(self.store)
+
+    def iterator(self, prefix=b'', seek=None, reverse=False):
+        keys = sorted(k for k in self.store if k.startswith(prefix))
+        if seek is not None:
+            keys = [k for k in keys if k >= seek]
+        for key in keys:
+            yield key, self.store[key]
+
+
+class _Logger:
+    def info(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+    def exception(self, *a, **k):
+        pass
+
+
+class _CBORFreeToken:
+    """Stand-in for GlyphTokenInfo: the migrators only read `metadata_hash`."""
+
+    MARKER = b'MH:'
+
+    @classmethod
+    def from_bytes(cls, data):
+        if not data.startswith(cls.MARKER):
+            raise ValueError('not a token row')
+        return SimpleNamespace(metadata_hash=data[len(cls.MARKER):])
+
+
+def _index(rows, metadata_by_hash, monkeypatch_target=gi):
+    """Build a bare GlyphIndex over a stub DB. __init__ opens real storage, so bypass it and wire
+    in only what the migrators touch."""
+    idx = object.__new__(GlyphIndex)
+    idx.db = SimpleNamespace(utxo_db=_StubUtxoDB())
+    idx.logger = _Logger()
+    idx.metadata_cache = {}
+    for ref, meta_hash in rows:
+        idx.db.utxo_db.store[GlyphDBKeys.TOKEN + ref] = _CBORFreeToken.MARKER + meta_hash
+    idx.get_metadata = lambda h: metadata_by_hash.get(h)
+    return idx
+
+
+def _run(idx, migrator_name):
+    saved = gi.GlyphTokenInfo.from_bytes
+    gi.GlyphTokenInfo.from_bytes = _CBORFreeToken.from_bytes
+    try:
+        return getattr(idx, migrator_name)()
+    finally:
+        gi.GlyphTokenInfo.from_bytes = saved
+
+
+def _written(idx, prefix):
+    return sorted(k for k in idx.db.utxo_db.store if k.startswith(prefix))
+
+
+# --------------------------------------------------------------------------- v4 -> v5 (GCM)
+
+def test_gcm_migration_derives_the_live_key():
+    idx = _index([(REF_A, b'h1')], {b'h1': {'in': [CONTAINER]}})
+    assert _run(idx, '_migrate_4_to_5') == 1
+    # Exactly the key the live flush path writes: GCM + container_ref + member_ref.
+    assert _written(idx, GlyphDBKeys.CONTAINER_MEMBERS) == [
+        GlyphDBKeys.CONTAINER_MEMBERS + CONTAINER + REF_A
+    ]
+
+
+def test_gcm_migration_unwraps_cbor_tags():
+    tagged = SimpleNamespace(value=CONTAINER)   # what cbor2 hands back for a tagged bytestring
+    idx = _index([(REF_A, b'h1')], {b'h1': {'in': [tagged]}})
+    assert _run(idx, '_migrate_4_to_5') == 1
+    assert _written(idx, GlyphDBKeys.CONTAINER_MEMBERS) == [
+        GlyphDBKeys.CONTAINER_MEMBERS + CONTAINER + REF_A
+    ]
+
+
+def test_gcm_migration_ignores_malformed_in_fields():
+    idx = _index(
+        [(REF_A, b'h1'), (REF_B, b'h2'), (REF_C, b'h3')],
+        {
+            b'h1': {'in': []},                    # empty
+            b'h2': {'in': [b'\x01' * 35]},        # wrong length
+            b'h3': {'in': 'not-a-list'},          # wrong type
+        },
+    )
+    assert _run(idx, '_migrate_4_to_5') == 0
+    assert _written(idx, GlyphDBKeys.CONTAINER_MEMBERS) == []
+
+
+def test_gcm_migration_is_idempotent():
+    idx = _index([(REF_A, b'h1')], {b'h1': {'in': [CONTAINER]}})
+    _run(idx, '_migrate_4_to_5')
+    before = dict(idx.db.utxo_db.store)
+    _run(idx, '_migrate_4_to_5')
+    assert idx.db.utxo_db.store == before
+
+
+# --------------------------------------------------------------------------- v5 -> v6 (GMT)
+
+def test_gmt_migration_matches_live_normalisation():
+    idx = _index([(REF_A, b'h1')], {b'h1': {'type': '  User  '}})
+    assert _run(idx, '_migrate_5_to_6') == 1
+    # Live path: sha256(raw.strip().lower())[:16] -- normalisation must match or nothing resolves.
+    expected = GlyphDBKeys.BY_META_TYPE + sha256(b'user')[:16] + REF_A
+    assert _written(idx, GlyphDBKeys.BY_META_TYPE) == [expected]
+
+
+def test_gmt_migration_skips_empty_and_non_string_types():
+    idx = _index(
+        [(REF_A, b'h1'), (REF_B, b'h2'), (REF_C, b'h3')],
+        {b'h1': {'type': '   '}, b'h2': {'type': 123}, b'h3': {}},
+    )
+    assert _run(idx, '_migrate_5_to_6') == 0
+    assert _written(idx, GlyphDBKeys.BY_META_TYPE) == []
+
+
+def test_gmt_migration_groups_refs_under_one_type():
+    idx = _index(
+        [(REF_A, b'h1'), (REF_B, b'h2')],
+        {b'h1': {'type': 'container'}, b'h2': {'type': 'CONTAINER'}},
+    )
+    assert _run(idx, '_migrate_5_to_6') == 2
+    type_hash = sha256(b'container')[:16]
+    assert _written(idx, GlyphDBKeys.BY_META_TYPE) == sorted([
+        GlyphDBKeys.BY_META_TYPE + type_hash + REF_A,
+        GlyphDBKeys.BY_META_TYPE + type_hash + REF_B,
+    ])
+
+
+# --------------------------------------------------------------------------- shared driver
+
+def test_tokens_without_metadata_are_skipped():
+    # No metadata_hash, and a hash whose GM row is gone (denylist-scrubbed) -- both are skipped
+    # rather than raising, since there is nothing to derive a key from.
+    idx = _index([(REF_A, b''), (REF_B, b'missing')], {})
+    assert _run(idx, '_migrate_4_to_5') == 0
+    assert _run(idx, '_migrate_5_to_6') == 0
+
+
+def test_unparseable_token_rows_do_not_abort_the_walk():
+    idx = _index([(REF_A, b'h1')], {b'h1': {'type': 'user'}})
+    idx.db.utxo_db.store[GlyphDBKeys.TOKEN + REF_B] = b'GARBAGE'   # fails from_bytes
+    idx.db.utxo_db.store[GlyphDBKeys.TOKEN + b'\x00' * 4] = b'MH:h1'  # ref wrong length
+    assert _run(idx, '_migrate_5_to_6') == 1
+
+
+def test_page_walk_resumes_strictly_after_the_last_key():
+    rows = [(bytes([i]) * 36, b'h%d' % i) for i in range(1, 6)]
+    idx = _index(rows, {})
+    seen = []
+    seek = GlyphDBKeys.TOKEN
+    saved = gi.GlyphTokenInfo.from_bytes
+    gi.GlyphTokenInfo.from_bytes = _CBORFreeToken.from_bytes
+    try:
+        while True:
+            items, seek = idx._read_token_page(seek, 2)
+            seen.extend(ref for ref, _t in items)
+            if seek is None:
+                break
+    finally:
+        gi.GlyphTokenInfo.from_bytes = saved
+    # Every row exactly once, in key order -- no duplicates from an inclusive seek, no gaps.
+    assert seen == [ref for ref, _h in rows]
+
+
+def test_migration_chain_is_registered_for_every_step():
+    # A gap here is what produced "version 4 < 6 has no in-place migration" on deploy.
+    src = open(os.path.join(os.path.dirname(__file__), '..', 'electrumx', 'server',
+                            'glyph_index.py'), encoding='utf-8').read()
+    for step in ('3: self._migrate_3_to_4', '4: self._migrate_4_to_5', '5: self._migrate_5_to_6'):
+        assert step in src, f'missing migration step: {step}'
+    assert 'CURRENT_SCHEMA_VERSION = 6' in src
+
+
+if __name__ == '__main__':
+    import pytest
+    sys.exit(pytest.main([__file__, '-v']))

--- a/tests/test_hashmark_index.py
+++ b/tests/test_hashmark_index.py
@@ -1,0 +1,489 @@
+"""
+Tests for the HashMark digest index.
+
+Covers the parser against the test vectors in the HashMark spec (§7), plus a round-trip through
+the index itself: flush -> lookup ordering -> reorg unwind.  Run:
+PYTHONPATH=. python3 -m pytest tests/test_hashmark_index.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from electrumx.server.hashmark_index import (  # noqa: E402
+    HashMarkIndex, HashMarkRecord, HashMarkDBKeys,
+    parse_hashmark, read_pushes, parse_digest_arg, resolve_algorithm,
+    MAGIC, HASHMARK_PREFIX,
+)
+
+DIGEST = bytes([0xAA]) * 32
+DIGEST_HEX = DIGEST.hex()
+
+
+def script(*parts: bytes) -> bytes:
+    return b''.join(parts)
+
+
+def push(data: bytes) -> bytes:
+    """Minimal push encoding, as a HashMark writer must produce."""
+    if len(data) <= 0x4B:
+        return bytes([len(data)]) + data
+    if len(data) <= 0xFF:
+        return bytes([0x4C, len(data)]) + data
+    return bytes([0x4D, len(data) & 0xFF, len(data) >> 8]) + data
+
+
+OP_RETURN = b'\x6a'
+HEADER_V1_SHA256 = push(bytes([1, 1]))
+
+
+def valid_script(digest=DIGEST, label=None, header=HEADER_V1_SHA256):
+    parts = [OP_RETURN, push(MAGIC), header, push(digest)]
+    if label is not None:
+        parts.append(push(label))
+    return script(*parts)
+
+
+SIGNER = bytes([0x26]) * 20
+SIGNATURE = bytes([0x1F]) + bytes([0xAB]) * 64
+HEADER_V2_SHA256 = push(bytes([2, 1]))
+
+
+def v2_script(digest=DIGEST, label=None, header=HEADER_V2_SHA256,
+              signer=SIGNER, signature=SIGNATURE):
+    parts = [OP_RETURN, push(MAGIC), header, push(digest), push(signer), push(signature)]
+    if label is not None:
+        parts.append(push(label))
+    return script(*parts)
+
+
+# --------------------------------------------------------------------------- parser: accept
+
+def test_prefix_is_the_ten_documented_bytes():
+    assert HASHMARK_PREFIX == bytes.fromhex('6a0848415348' '4d41524b')
+    assert len(HASHMARK_PREFIX) == 10
+    assert valid_script().startswith(HASHMARK_PREFIX)
+
+
+def test_record_with_no_label():
+    raw = valid_script()
+    assert len(raw) == 46, 'spec §7: unlabelled record is 46 bytes'
+    rec = parse_hashmark(raw)
+    assert isinstance(rec, HashMarkRecord), rec
+    assert rec.version == 1
+    assert rec.algorithm_id == 1
+    assert rec.algorithm == 'sha256'
+    assert rec.digest.hex() == DIGEST_HEX
+    assert rec.label is None
+
+
+def test_record_with_label():
+    rec = parse_hashmark(valid_script(label=b'hi'))
+    assert isinstance(rec, HashMarkRecord), rec
+    assert rec.digest.hex() == DIGEST_HEX
+    assert rec.label == 'hi'
+
+
+def test_max_length_label_is_accepted():
+    rec = parse_hashmark(valid_script(label=b'x' * 128))
+    assert isinstance(rec, HashMarkRecord), rec
+    assert rec.label == 'x' * 128
+    # The spec's stated 176-byte ceiling is exactly this record.
+    assert len(valid_script(label=b'x' * 128)) == 176
+
+
+# --------------------------------------------------------------------------- parser: v2
+
+def test_v2_record_with_no_label():
+    raw = v2_script()
+    assert len(raw) == 133, 'unlabelled v2 record: 46 + 21 signer + 66 signature'
+    rec = parse_hashmark(raw)
+    assert isinstance(rec, HashMarkRecord), rec
+    assert rec.version == 2
+    assert rec.digest == DIGEST
+    assert rec.signer_hash160 == SIGNER
+    assert rec.label is None
+
+
+def test_v2_reads_the_label_from_push_five():
+    # The whole reason an unknown version must not be guessed at: in v1 this position holds the
+    # digest's neighbour, in v2 it holds a signature.
+    rec = parse_hashmark(v2_script(label=b'Contract draft'))
+    assert isinstance(rec, HashMarkRecord), rec
+    assert rec.label == 'Contract draft'
+    assert rec.signer_hash160 == SIGNER
+
+
+def test_v2_label_cap_is_lower_than_v1():
+    # v2 spends 87 bytes on the attestation, so the label budget shrinks to 88.
+    assert isinstance(parse_hashmark(v2_script(label=b'x' * 88)), HashMarkRecord)
+    assert parse_hashmark(v2_script(label=b'x' * 89)) == 'INVALID'
+    # v1 keeps its own, larger cap.
+    assert isinstance(parse_hashmark(valid_script(label=b'x' * 128)), HashMarkRecord)
+
+
+def test_v2_rejects_a_wrong_sized_signer_or_signature():
+    assert parse_hashmark(v2_script(signer=bytes([0x26]) * 19)) == 'INVALID'
+    assert parse_hashmark(v2_script(signature=bytes([0xAB]) * 64)) == 'INVALID'
+
+
+def test_v2_rejects_a_v1_push_count():
+    # Missing the signature entirely.
+    raw = script(OP_RETURN, push(MAGIC), HEADER_V2_SHA256, push(DIGEST), push(SIGNER))
+    assert parse_hashmark(raw) == 'INVALID'
+
+
+def test_v2_signature_is_not_verified_here():
+    # A signature of the right shape but no cryptographic meaning is still indexed: this index is
+    # a search hint, and the client recovers the key and checks it against the commitment itself.
+    rec = parse_hashmark(v2_script(signature=bytes([0x1F]) + bytes(64)))
+    assert isinstance(rec, HashMarkRecord), rec
+
+
+# --------------------------------------------------------------------------- parser: reject
+
+def test_short_digest_is_invalid():
+    assert parse_hashmark(valid_script(digest=bytes([0xAA]) * 31)) == 'INVALID'
+
+
+def test_future_version_is_not_indexed_as_a_known_one():
+    # 3, not 2: v2 is a format this index reads, so a v1-shaped record claiming version 2 is a
+    # malformed v2 record rather than an unknown version.  A version from the future is the case
+    # this test is about.
+    assert parse_hashmark(valid_script(header=push(bytes([3, 1])))) == 'UNKNOWN_VERSION'
+
+
+def test_a_v2_shaped_record_claiming_v1_is_invalid():
+    # The reverse mistake: right pushes, wrong version byte.  Reading it as v1 would index a
+    # signature as a label.
+    raw = v2_script(header=HEADER_V1_SHA256)
+    assert parse_hashmark(raw) == 'INVALID'
+
+
+def test_unknown_algorithm():
+    assert parse_hashmark(valid_script(header=push(bytes([1, 2])))) == 'UNKNOWN_ALGORITHM'
+
+
+def test_non_minimal_push_is_not_a_hashmark():
+    # PUSHDATA1 used for a 32-byte digest that fits a direct push.
+    raw = script(OP_RETURN, push(MAGIC), HEADER_V1_SHA256, bytes([0x4C, 0x20]), DIGEST)
+    assert parse_hashmark(raw) == 'NOT_HASHMARK'
+
+
+def test_another_protocol_is_not_a_hashmark():
+    raw = bytes.fromhex('6a036d735706736e6b00336b')
+    assert parse_hashmark(raw) == 'NOT_HASHMARK'
+    assert not raw.startswith(HASHMARK_PREFIX)
+
+
+def test_small_int_opcodes_are_rejected():
+    # OP_1 (0x51) would give a one-byte field a second spelling.
+    raw = script(OP_RETURN, push(MAGIC), b'\x51', push(DIGEST))
+    assert parse_hashmark(raw) == 'NOT_HASHMARK'
+
+
+def test_oversized_label_is_invalid():
+    assert parse_hashmark(valid_script(label=b'x' * 129)) == 'INVALID'
+
+
+def test_empty_label_cannot_be_encoded():
+    # An empty 4th push can only be spelled OP_0, which the minimal-push rule rejects outright —
+    # so "label present but empty" is unrepresentable rather than merely invalid.
+    assert parse_hashmark(valid_script(label=b'')) == 'NOT_HASHMARK'
+
+
+def test_control_characters_and_bad_utf8_in_label_are_invalid():
+    assert parse_hashmark(valid_script(label=b'a\x01b')) == 'INVALID'
+    assert parse_hashmark(valid_script(label=b'\xff\xfe')) == 'INVALID'
+
+
+def test_two_pushes_or_five_pushes_are_invalid():
+    assert parse_hashmark(script(OP_RETURN, push(MAGIC), HEADER_V1_SHA256)) == 'INVALID'
+    assert parse_hashmark(valid_script(label=b'hi') + push(b'extra')) == 'INVALID'
+
+
+def test_non_op_return_output():
+    assert parse_hashmark(b'\x76\xa9\x14' + b'\x00' * 20 + b'\x88\xac') == 'NOT_HASHMARK'
+    assert parse_hashmark(b'') == 'NOT_HASHMARK'
+
+
+def test_read_pushes_rejects_truncated_push():
+    assert read_pushes(b'\x20\xaa\xbb', 0) is None
+
+
+# --------------------------------------------------------------------------- argument validation
+
+def test_digest_argument_is_strict():
+    assert parse_digest_arg(DIGEST_HEX, 1) == DIGEST
+    assert parse_digest_arg(DIGEST_HEX.upper(), 1) is None      # uppercase
+    assert parse_digest_arg(DIGEST_HEX[:32], 1) is None         # partial -> no enumeration
+    assert parse_digest_arg(DIGEST_HEX + 'aa', 1) is None
+    assert parse_digest_arg('zz' * 32, 1) is None
+    assert parse_digest_arg(DIGEST_HEX, 99) is None
+    assert parse_digest_arg(None, 1) is None
+
+
+def test_algorithm_resolution():
+    assert resolve_algorithm('sha256') == 1
+    assert resolve_algorithm(1) == 1
+    assert resolve_algorithm('1') == 1
+    assert resolve_algorithm('sha512') is None
+    assert resolve_algorithm(2) is None
+    assert resolve_algorithm(True) is None      # bool is an int subclass; must not pass as id 1
+
+
+# --------------------------------------------------------------------------- index round-trip
+
+class _Out:
+    def __init__(self, script_bytes):
+        self.pk_script = script_bytes
+
+
+class _Tx:
+    def __init__(self, scripts):
+        self.outputs = [_Out(s) for s in scripts]
+
+
+class _Batch:
+    """Collects puts/deletes and applies them to the stub store on exit, like a RocksDB batch."""
+
+    def __init__(self, store):
+        self.store = store
+        self.ops = []
+
+    def put(self, key, value):
+        self.ops.append(('put', key, value))
+
+    def delete(self, key):
+        self.ops.append(('del', key, None))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        for op, key, value in self.ops:
+            if op == 'put':
+                self.store[key] = value
+            else:
+                self.store.pop(key, None)
+        return False
+
+
+class _StubUtxoDB:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def write_batch(self):
+        return _Batch(self.store)
+
+    def iterator(self, prefix=b'', seek=None, reverse=False):
+        keys = sorted(k for k in self.store if k.startswith(prefix))
+        if reverse:
+            keys = list(reversed(keys))
+        for key in keys:
+            yield key, self.store[key]
+
+
+class _StubDB:
+    def __init__(self):
+        self.utxo_db = _StubUtxoDB()
+        self.db_height = 500000
+
+
+class _Env:
+    hashmark_index = True
+    reorg_limit = 200
+
+
+def _index():
+    return HashMarkIndex(_StubDB(), _Env())
+
+
+def _mark(idx, txid_byte, height, label=None, digest=DIGEST, vout_scripts=None):
+    tx = _Tx(vout_scripts or [valid_script(digest=digest, label=label)])
+    idx.process_tx(bytes([txid_byte]) * 32, tx, height, bytes([height & 0xFF]) * 32)
+
+
+def _flush(idx):
+    with idx.db.utxo_db.write_batch() as batch:
+        idx.flush(batch)
+
+
+def test_lookup_returns_marks_oldest_first():
+    idx = _index()
+    # Recorded out of order; the key layout must still yield height-ascending results.
+    _mark(idx, 0x22, 400)
+    _mark(idx, 0x11, 100, label=b'first')
+    _mark(idx, 0x33, 900)
+    _flush(idx)
+
+    hits = idx.lookup(DIGEST, 1, 20)
+    assert [h['height'] for h in hits] == [100, 400, 900]
+    assert hits[0]['label'] == 'first'
+    assert 'label' not in hits[1], 'absent label must be omitted, not null'
+    assert hits[0]['txid'] == (bytes([0x11]) * 32)[::-1].hex()
+    assert hits[0]['block_hash'] == (bytes([100]) * 32)[::-1].hex()
+    assert hits[0]['algorithm'] == 'sha256'
+    assert hits[0]['version'] == 1
+    assert hits[0]['digest'] == DIGEST_HEX
+    assert hits[0]['output_index'] == 0
+
+
+def test_lookup_returns_the_committed_signer_for_v2_marks():
+    idx = _index()
+    # The same file marked twice: once under v1, once under v2 by a key. Both are real, neither
+    # supersedes the other, and only the v2 row can say who made it.
+    _mark(idx, 0x11, 100)
+    idx.process_tx(bytes([0x22]) * 32, _Tx([v2_script(label=b'signed')]), 400,
+                   bytes([400 & 0xFF]) * 32)
+    _flush(idx)
+
+    hits = idx.lookup(DIGEST, 1, 20)
+    assert [h['version'] for h in hits] == [1, 2]
+    assert 'signer_hash160' not in hits[0], 'a v1 row has no signer to report'
+    assert hits[1]['signer_hash160'] == SIGNER.hex()
+    assert hits[1]['label'] == 'signed'
+
+
+def test_v1_rows_written_before_v2_existed_still_read_back():
+    # The stored value is version-led, so an old row is read the old way and no rescan is needed.
+    idx = _index()
+    _mark(idx, 0x11, 100, label=b'old')
+    _flush(idx)
+    hits = idx.lookup(DIGEST, 1, 20)
+    assert hits[0]['version'] == 1
+    assert hits[0]['label'] == 'old'
+    assert 'signer_hash160' not in hits[0]
+
+
+def test_unmarked_digest_returns_empty_list():
+    idx = _index()
+    _mark(idx, 0x11, 100)
+    _flush(idx)
+    assert idx.lookup(bytes([0xBB]) * 32, 1, 20) == []
+
+
+def test_limit_is_honoured():
+    idx = _index()
+    for i in range(10):
+        _mark(idx, 0x10 + i, 100 + i)
+    _flush(idx)
+    assert len(idx.lookup(DIGEST, 1, 3)) == 3
+    assert [h['height'] for h in idx.lookup(DIGEST, 1, 3)] == [100, 101, 102]
+
+
+def test_same_tx_multiple_outputs_are_separate_rows():
+    idx = _index()
+    tx = _Tx([valid_script(label=b'a'), b'\x6a\x04test', valid_script(label=b'b')])
+    idx.process_tx(bytes([0x11]) * 32, tx, 100, bytes([1]) * 32)
+    _flush(idx)
+    hits = idx.lookup(DIGEST, 1, 20)
+    assert [h['output_index'] for h in hits] == [0, 2]
+
+
+def test_invalid_outputs_are_not_indexed():
+    idx = _index()
+    tx = _Tx([
+        valid_script(header=push(bytes([2, 1]))),      # UNKNOWN_VERSION
+        valid_script(digest=bytes([0xAA]) * 31),       # INVALID
+        bytes.fromhex('6a036d735706736e6b00336b'),     # another protocol
+    ])
+    idx.process_tx(bytes([0x11]) * 32, tx, 100, bytes([1]) * 32)
+    _flush(idx)
+    assert idx.lookup(DIGEST, 1, 20) == []
+    assert idx._pending_rows == 0
+
+
+def test_reorg_removes_only_the_disconnected_block():
+    idx = _index()
+    _mark(idx, 0x11, 100)
+    _mark(idx, 0x22, 101)
+    _flush(idx)
+    assert len(idx.lookup(DIGEST, 1, 20)) == 2
+
+    with idx.db.utxo_db.write_batch() as batch:
+        idx.backup(batch, 101)
+
+    hits = idx.lookup(DIGEST, 1, 20)
+    assert [h['height'] for h in hits] == [100], 'block 100 must survive an unwind of block 101'
+    assert idx.db.utxo_db.get(HashMarkDBKeys.UNDO + b'\x00\x00\x00\x65') is None
+
+
+def test_reorg_then_reindex_does_not_duplicate():
+    idx = _index()
+    _mark(idx, 0x11, 100)
+    _flush(idx)
+    with idx.db.utxo_db.write_batch() as batch:
+        idx.backup(batch, 100)
+    assert idx.lookup(DIGEST, 1, 20) == []
+
+    # Same tx re-mined at a new height on the new chain.
+    _mark(idx, 0x11, 100)
+    _flush(idx)
+    assert len(idx.lookup(DIGEST, 1, 20)) == 1
+
+
+def test_disabled_index_records_nothing():
+    class _Off(_Env):
+        hashmark_index = False
+
+    idx = HashMarkIndex(_StubDB(), _Off())
+    _mark(idx, 0x11, 100)
+    _flush(idx)
+    assert idx.db.utxo_db.store == {}
+
+
+def test_fresh_sync_needs_no_backfill():
+    # A from-genesis resync (what the DB_VERSIONS bump forces) indexes every block live, so the
+    # historic scan must resolve to an empty range rather than re-reading the chain.
+    db = _StubDB()
+    db.db_height = -1
+    idx = HashMarkIndex(db, _Env())
+    _mark(idx, 0x11, 0)
+    _flush(idx)
+    assert idx.db.utxo_db.get(HashMarkDBKeys.LIVE_FROM) == b'\x00\x00\x00\x00'
+    assert idx._backfill_target(500000) == -1
+
+
+def test_enabling_on_a_synced_db_backfills_everything_below():
+    db = _StubDB()
+    db.db_height = 500000
+    idx = HashMarkIndex(db, _Env())
+    _mark(idx, 0x11, 500001)
+    _flush(idx)
+    # Live coverage starts at 500001, so the scan must cover 0..500000.
+    assert idx._backfill_target(500001) == 500000
+
+
+def test_live_from_watermark_is_written_once():
+    db = _StubDB()
+    db.db_height = 100
+    idx = HashMarkIndex(db, _Env())
+    _mark(idx, 0x11, 101)
+    _flush(idx)
+    assert idx._backfill_target(0) == 100
+
+    # A later flush at a higher height must not move the watermark forward.
+    db.db_height = 200
+    idx2 = HashMarkIndex(db, _Env())
+    _mark(idx2, 0x22, 201)
+    _flush(idx2)
+    assert idx2._backfill_target(0) == 100
+
+
+def test_stats_reports_backfill_progress():
+    idx = _index()
+    stats = idx.stats()
+    assert stats['enabled'] is True
+    assert stats['backfill_complete'] is False
+    assert stats['algorithms'] == {'sha256': 1}
+    assert stats['protocol_version'] == 2
+    assert stats['protocol_versions'] == [1, 2]
+
+
+if __name__ == '__main__':
+    import pytest
+    sys.exit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
Three independent changes, one commit each, in dependency order.

## 1. HashMark digest index (`ba89072`)

Digest lookup is the one HashMark operation no existing Radiant infrastructure
can serve: `blockchain.ref.get` indexes Glyph refs rather than data-output
payloads, and every other scanner in this tree is gated on its own magic, so a
HashMark output leaves no trace in the DB. That gap is what would otherwise
force HashMark to run a second process duplicating block-following, reorg
handling and confirmation tracking.

Detection is a 10-byte prefix compare against every output. Rows live in one
`HMd` keyspace keyed `(algorithm, digest, height, txid, vout)`, so a prefix scan
emerges height-ascending and the API returns oldest first for free. Each row
stores the block hash it was mined in, which makes reorg unwind exact.

**Both record versions are indexed.** v1 is 3–4 pushes ending in an optional
label; v2 adds a 20-byte committed signer and a 65-byte signature after the
digest, moving the label from push 3 to push 5. That move is exactly why an
unknown version must never be read under a known version's rules — a v1 parser
let loose on a v2 record would index a signature as a label. The stored value is
version-led, so rows written before v2 existed read back unchanged and no rescan
is needed.

The signature is deliberately **not** verified here: that needs secp256k1 and the
chain's genesis hash, and would change nothing, because HashMark re-fetches every
hit and checks the signature against the committed signer itself. A hit means
"this script is on chain at this height" and nothing more — so a bug here can
cause a missed result, never a false one.

Exposed as `hashmark.lookup` / `hashmark.stats` over ElectrumX and
`GET /hashmark/{digest}` / `/hashmark/stats` over REST. Digests match whole: no
prefix matching, which would let a caller enumerate the index a nibble at a time.

39 tests: parser vectors, both versions' shapes and caps, storage round trip
including a pre-v2 row, lookup ordering, reorg unwind.

*One wrinkle worth flagging in review:* the security middleware allowlist gains
`/containers` and `/users` alongside `/hashmark` in this commit. The three paths
are one contiguous block, and splitting them would leave this commit's own routes
blocked; the container routes arrive in commit 2.

## 2. Glyph container and metadata-type indexes (`7ef4700`)

`GCM` answers "what is in this container", `GMT` answers "which tokens declare
this metadata type" — the latter is what makes user profiles listable, since a
user is a token whose metadata type is `user` rather than a distinct kind.

Both are pure functions of CBOR metadata already stored in `GM` rows, so the
v4→v5 and v5→v6 migrations backfill **in place**: no radiantd rescan, no block
reprocessing. They share one driver and are idempotent, so a run interrupted
before the version stamp is safe to repeat. The walk pages through
`_read_token_page`, which fully drains its iterator before returning so a
caller's `write_batch` never overlaps an open RocksDB iterator.

v5/v6 were developed as v4/v5 against a v3 base, before the recency indexes took
v4 upstream; they are renumbered so the chain stays linear.

Also fixes token classification: `CONTAINER` is checked before `AUTHORITY`, so a
container+authority token (`[2,7,10]`) classifies the same way here as in
`get_token_type`.

## 3. REST rate-limit exemptions, and a db_engine fix (`55cd96c`)

`REST_RATE_LIMIT_EXEMPT` lists networks that bypass the per-IP limiter, with
`private` as shorthand for the usual RFC1918 / loopback / link-local / ULA set.
The match is against the **resolved client address, not the immediate peer**, so
a public client arriving through a private-IP reverse proxy is still limited.
Unparseable tokens are skipped rather than failing startup.

`/health/db` and `/status` read `db_engine` off the db object, where it actually
lives on `db.env` (`db.py` uses `self.env.db_engine`), so both had been reporting
`unknown`. The `mock_db` fixture had the same mistake, which is why it went
unnoticed — corrected here, since otherwise the fix surfaces as three
RecursionErrors when FastAPI tries to serialise an auto-created Mock attribute.

## Testing

`tests/test_hashmark_index.py` 39 passed · `tests/test_glyph_schema_migrations.py`
passed · `tests/server/test_rest_api.py` 102 passed.

One failure remains, `TestTokenAnalyticsEndpoints::test_get_metadata`, and it is
**pre-existing** — it fails identically at `ca8a6a4`, before any of this work.
Not addressed here.

The HashMark index is also verified against mainnet: transaction
`345565eb…88892` (v1) and `a1a86ab4…045916` (v2, signed) are both indexed and
returned by digest lookup, and both re-verify against the chain.
